### PR TITLE
Migrate to SignalFx error attributes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,10 +224,10 @@ jobs:
           command: mkdir -p test-results/phpcs
       - run:
           name: Running eclint
-          command: node_modules/.bin/eclint check '**/*' '!config.*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!LICENSE' '!phpstan.neon' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' || touch .failure
+          command: node_modules/.bin/eclint check '**/*' '!config.*' '!tmp/**/*' '!vendor/**/*' '!src/ext/.libs/*' '!LICENSE' '!phpstan.neon' '!tests/Frameworks/*/Version_*/**' '!tests/dockerfiles/**' '!dockerfiles/**' '!tests/AutoInstrumentation/**' '!.composer/**/*' '!src/ext/mpack/**' '!src/ext/third-party/**' '!.config/**/*' '!.npm/**/*' '!extensions/*.so'
       - run:
           name: Running phpcs
-          command: composer lint -- --report=junit | tee test-results/phpcs/results.xml || touch .failure
+          command: composer lint -- --report=junit > test-results/phpcs/results.xml
       - run:
           name: Install Clang
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+local/
 **/vendor/
 tmp/build_extension/
 composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+- Migrated to SignalFx error attributes from OpenTracing
+
 ## [0.30.1]
 ### Fixed
 - releasing This object as soon as it stops being used #536

--- a/local-build.sh
+++ b/local-build.sh
@@ -6,13 +6,14 @@ rm -rf extensions
 mkdir -p extensions
 rm -rf build/packages
 mkdir -p build/packages
+mkdir -p docs
 
 function build_version() {
     PHP_VERSION=$1
     PHP_API=$2
     SUFFIX=${3:-''}
     rm -rf tmp
-    docker run --rm -w /var/app -v $(pwd):/var/app circleci/php:${PHP_VERSION}${SUFFIX} make all CFLAGS="-O2 -std=c99 -Wall -Wextra -Wextra"
+    docker run --rm -w /var/app -v $(pwd):/var/app circleci/php:${PHP_VERSION}${SUFFIX} make all CFLAGS="-O2 -std=c99 -Wall -Wextra -Wextra -D_POSIX_C_SOURCE=199309L"
     docker run --rm -w /var/app -v $(pwd):/var/app circleci/php:${PHP_VERSION}${SUFFIX} cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-${PHP_API}${SUFFIX}.so
 }
 
@@ -20,7 +21,7 @@ function build_version_54() {
     PHP_VERSION=5.4
     PHP_API=20100412
     rm -rf tmp
-    docker run --rm -w /var/app -v $(pwd):/var/app datadog/docker-library:ddtrace_centos_6_php_5_4 make all CFLAGS="-O2 -std=c99 -Wall -Wextra -Wextra" ECHO_ARG="-e"
+    docker run --rm -w /var/app -v $(pwd):/var/app datadog/docker-library:ddtrace_centos_6_php_5_4 make all CFLAGS="-O2 -std=c99 -Wall -Wextra -Wextra -D_POSIX_C_SOURCE=199309L" ECHO_ARG="-e"
     docker run --rm -w /var/app -v $(pwd):/var/app datadog/docker-library:ddtrace_centos_6_php_5_4 cp tmp/build_extension/.libs/ddtrace.so extensions/ddtrace-${PHP_API}.so
 }
 

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -177,8 +177,8 @@ final class Span extends SpanData
 
             if ($key === Tag::HTTP_STATUS_CODE && $value >= 500) {
                 $this->hasError = true;
-                if (!isset($this->tags[Tag::ERROR_TYPE])) {
-                    $this->tags[Tag::ERROR_TYPE] = 'Internal Server Error';
+                if (!isset($this->tags[Tag::ERROR_KIND])) {
+                    $this->tags[Tag::ERROR_KIND] = 'Internal Server Error';
                 }
             }
 
@@ -285,7 +285,7 @@ final class Span extends SpanData
 
     /**
      * @param string $message
-     * @param string $type
+     * @param string $kind
      */
     public function setRawError($message, $kind)
     {

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -266,7 +266,7 @@ final class Span extends SpanData
         if (($error instanceof Exception) || ($error instanceof Throwable)) {
             $this->hasError = true;
             $this->tags[Tag::ERROR_MSG] = $error->getMessage();
-            $this->tags[Tag::ERROR_TYPE] = get_class($error);
+            $this->tags[Tag::ERROR_KIND] = get_class($error);
             $this->tags[Tag::ERROR_STACK] = $error->getTraceAsString();
             return;
         }
@@ -287,7 +287,7 @@ final class Span extends SpanData
      * @param string $message
      * @param string $type
      */
-    public function setRawError($message, $type)
+    public function setRawError($message, $kind)
     {
         if ($this->duration !== null) { // if finished
             return;
@@ -295,7 +295,7 @@ final class Span extends SpanData
 
         $this->hasError = true;
         $this->tags[Tag::ERROR_MSG] = $message;
-        $this->tags[Tag::ERROR_TYPE] = $type;
+        $this->tags[Tag::ERROR_KIND] = $kind;
     }
 
     public function hasError()

--- a/src/DDTrace/Tag.php
+++ b/src/DDTrace/Tag.php
@@ -18,9 +18,10 @@ class Tag
     const DB_INSTANCE = 'db.instance';
     const DB_USER = 'db.user';
     const ERROR = 'error';
-    const ERROR_MSG = 'error.msg'; // string representing the error message
-    const ERROR_TYPE = 'error.type'; // string representing the type of the error
-    const ERROR_STACK = 'error.stack'; // human readable version of the stack
+    const ERROR_MSG = 'sfx.error.message'; // string representing the error message
+    const ERROR_KIND = 'sfx.error.kind'; // short string representing the type of the error
+    const ERROR_STACK = 'sfx.error.stack'; // human readable version of the stack
+    const ERROR_TYPE = ERROR_KIND;
     const HTTP_METHOD = 'http.method';
     const HTTP_STATUS_CODE = 'http.status_code';
     const HTTP_URL = 'http.url';

--- a/src/ext/backtrace.c
+++ b/src/ext/backtrace.c
@@ -62,7 +62,7 @@ void ddtrace_install_backtrace_handler() {
         backtrace_globals.handler_installed = TRUE;
     }
 }
-#else   // defined(__GLIBC__) || defined(__APPLE__)
+#else  // defined(__GLIBC__) || defined(__APPLE__)
 void ddtrace_install_backtrace_handler() {
     // NOOP
 }

--- a/tests/Common/SpanAssertion.php
+++ b/tests/Common/SpanAssertion.php
@@ -88,20 +88,20 @@ final class SpanAssertion
     }
 
     /**
-     * @param string|null $errorType The expected error.type
-     * @param string|null $errorMessage The expected error.msg
+     * @param string|null $errorType The expected sfx.error.kind
+     * @param string|null $errorMessage The expected sfx.error.message
      * @return $this
      */
     public function setError($errorType = null, $errorMessage = null)
     {
         $this->hasError = true;
-        if (isset($this->exactTags[Tag::ERROR_TYPE])) {
+        if (isset($this->exactTags[Tag::ERROR_KIND])) {
             return $this;
         }
         if (null !== $errorType) {
-            $this->exactTags[Tag::ERROR_TYPE] = $errorType;
+            $this->exactTags[Tag::ERROR_KIND] = $errorType;
         } else {
-            $this->existingTags[] = Tag::ERROR_TYPE;
+            $this->existingTags[] = Tag::ERROR_KIND;
         }
         if (null !== $errorMessage) {
             $this->exactTags[Tag::ERROR_MSG] = $errorMessage;

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
@@ -71,8 +71,8 @@ final class CommonScenariosTest extends CLITestCase
             )->withExactTags([
                 'integration.name' => 'cakephp',
             ])->withExistingTagsNames([
-                'error.msg',
-                'error.stack'
+                'sfx.error.message',
+                'sfx.error.stack'
             ])->setError()
         ]);
     }

--- a/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
@@ -67,8 +67,8 @@ final class CommonScenariosTest extends CLITestCase
                 'integration.name' => 'laravel',
                 'component' => 'laravel'
             ])->withExistingTagsNames([
-                'error.msg',
-                'error.stack'
+                'sfx.error.message',
+                'sfx.error.stack'
             ])->setError()
         ]);
     }

--- a/tests/Integrations/CLI/Laravel/V6_0/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V6_0/CommonScenariosTest.php
@@ -67,8 +67,8 @@ final class CommonScenariosTest extends CLITestCase
                 'integration.name' => 'laravel',
                 'component' => 'laravel'
             ])->withExistingTagsNames([
-                'error.msg',
-                'error.stack'
+                'sfx.error.message',
+                'sfx.error.stack'
             ])->setError()
         ]);
     }

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -97,7 +97,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'integration.name' => 'cakephp',
                         'component' => 'cakephp',
                     ])->withExistingTagsNames([
-                        'error.stack'
+                        'sfx.error.stack'
                     ])->setError(null, 'Foo error'),
                     SpanAssertion::build(
                         'cakephp.view',

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -231,7 +231,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                     'component' => 'curl',
                     'http.method' => 'GET',
                 ])
-                ->withExistingTagsNames(['error.msg'])
+                ->withExistingTagsNames(['sfx.error.message'])
                 ->setError('curl error'),
         ]);
     }
@@ -255,7 +255,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                     'component' => 'curl',
                     'http.method' => 'GET',
                 ])
-                ->withExistingTagsNames(['error.msg'])
+                ->withExistingTagsNames(['sfx.error.message'])
                 ->setError('curl error'),
         ]);
     }

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -125,7 +125,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'component' => 'laravel',
                         'integration.name' => 'laravel',
                     ])
-                    ->withExistingTagsNames(['error.stack'])
+                    ->withExistingTagsNames(['sfx.error.stack'])
                     ->setError('Exception', 'Controller error'),
                     SpanAssertion::exists('laravel.event.handle'),
                 ],

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -84,7 +84,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'append ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'append',
                 ]))
-                ->withExistingTagsNames(['system.pid', 'error.msg', 'error.type', 'error.stack']),
+                ->withExistingTagsNames(['system.pid', 'sfx.error.message', 'sfx.error.kind', 'sfx.error.stack']),
         ]);
     }
 
@@ -121,7 +121,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.command' => 'appendByKey',
                     'memcached.server_key' => 'my_server',
                 ]))
-                ->withExistingTagsNames(['system.pid', 'error.msg', 'error.type', 'error.stack']),
+                ->withExistingTagsNames(['system.pid', 'sfx.error.message', 'sfx.error.kind', 'sfx.error.stack']),
         ]);
     }
 

--- a/tests/Integrations/Mysqli/MysqliTest.php
+++ b/tests/Integrations/Mysqli/MysqliTest.php
@@ -60,9 +60,9 @@ final class MysqliTest extends IntegrationTestCase
             SpanAssertion::build('mysqli_connect', 'mysqli', 'sql', 'mysqli_connect')
                 ->setError()
                 ->withExistingTagsNames([
-                    'error.msg',
-                    'error.type',
-                    'error.stack',
+                    'sfx.error.message',
+                    'sfx.error.kind',
+                    'sfx.error.stack',
                 ]),
         ]);
     }
@@ -224,9 +224,9 @@ final class MysqliTest extends IntegrationTestCase
             SpanAssertion::build('mysqli.__construct', 'mysqli', 'sql', 'mysqli.__construct')
                 ->setError()
                 ->withExistingTagsNames([
-                    'error.msg',
-                    'error.type',
-                    'error.stack',
+                    'sfx.error.message',
+                    'sfx.error.kind',
+                    'sfx.error.stack',
                 ]),
         ]);
     }

--- a/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
@@ -93,7 +93,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'integration.name' => 'slim',
                         'component' => 'slim',
                     ])->withExistingTagsNames([
-                        'error.stack'
+                        'sfx.error.stack'
                     ])->setError(null, 'Foo error'),
                 ],
             ]

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -105,7 +105,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'component' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
+                        ->withExistingTagsNames(['sfx.error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -107,7 +107,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'component' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
+                        ->withExistingTagsNames(['sfx.error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -114,7 +114,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'component' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
+                        ->withExistingTagsNames(['sfx.error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -116,7 +116,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'component' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
+                        ->withExistingTagsNames(['sfx.error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -115,7 +115,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'component' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
-                        ->withExistingTagsNames(['error.stack']),
+                        ->withExistingTagsNames(['sfx.error.stack']),
                     SpanAssertion::exists('symfony.kernel.handle'),
                     SpanAssertion::exists('symfony.kernel.request'),
                     SpanAssertion::exists('symfony.kernel.controller'),

--- a/tests/OpenTracerUnit/SpanTest.php
+++ b/tests/OpenTracerUnit/SpanTest.php
@@ -57,7 +57,7 @@ final class SpanTest extends TestCase
 
         $this->assertTrue($span->unwrapped()->hasError());
         $this->assertEquals($span->unwrapped()->getTag(Tag::ERROR_MSG), self::EXCEPTION_MESSAGE);
-        $this->assertEquals($span->unwrapped()->getTag(Tag::ERROR_TYPE), 'Exception');
+        $this->assertEquals($span->unwrapped()->getTag(Tag::ERROR_KIND), 'Exception');
     }
 
     public function testSpanTagWithErrorBoolProperlyMarksError()
@@ -109,7 +109,7 @@ final class SpanTest extends TestCase
 
             $this->assertTrue($span->unwrapped()->hasError());
             $this->assertEquals($span->unwrapped()->getTag(Tag::ERROR_MSG), self::EXCEPTION_MESSAGE);
-            $this->assertEquals($span->unwrapped()->getTag(Tag::ERROR_TYPE), 'Exception');
+            $this->assertEquals($span->unwrapped()->getTag(Tag::ERROR_KIND), 'Exception');
         }
     }
 

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -82,7 +82,7 @@ final class SpanTest extends Framework\TestCase
 
         $this->assertTrue($span->hasError());
         $this->assertEquals($span->getTag(Tag::ERROR_MSG), self::EXCEPTION_MESSAGE);
-        $this->assertEquals($span->getTag(Tag::ERROR_TYPE), 'Exception');
+        $this->assertEquals($span->getTag(Tag::ERROR_KIND), 'Exception');
     }
 
     public function testSpanTagWithErrorBoolProperlyMarksError()
@@ -143,7 +143,7 @@ final class SpanTest extends Framework\TestCase
 
             $this->assertTrue($span->hasError());
             $this->assertEquals($span->getTag(Tag::ERROR_MSG), self::EXCEPTION_MESSAGE);
-            $this->assertEquals($span->getTag(Tag::ERROR_TYPE), 'Exception');
+            $this->assertEquals($span->getTag(Tag::ERROR_KIND), 'Exception');
         }
     }
 
@@ -173,7 +173,7 @@ final class SpanTest extends Framework\TestCase
         $this->assertTrue($span->hasError());
         $this->assertEquals($span->getTag(Tag::ERROR_MSG), self::EXCEPTION_MESSAGE);
         $this->assertNotEmpty($span->getTag(Tag::ERROR_STACK));
-        $this->assertEquals($span->getTag(Tag::ERROR_TYPE), 'Exception');
+        $this->assertEquals($span->getTag(Tag::ERROR_KIND), 'Exception');
     }
 
     public function testSpanErrorRemainsImmutableAfterFinishing()


### PR DESCRIPTION
### Replace OpenTracing error logs with SignalFx tags

This PR changes how errors are recorded on spans. It uses the new
SignalFx semantic convention and records the errors as attributes
instead of logs.

In addition to updating errors, also fixes some CI lint jobs

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug

.