### PR TITLE
Add support for SIGNALFX_RECORDED_VALUE_MAX_LENGTH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ local/
 **/vendor/
 tmp/build_extension/
 composer.lock
+.bash_history
 .scenarios.lock/
 .vscode/
 .libs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file - [read more
 
 ## [Unreleased]
 
+- Added support SIGNALFX_RECORDED_VALUE_MAX_LENGTH to limit size of span attribute values
 - Migrated to SignalFx error attributes from OpenTracing
 
 ## [0.30.1]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Configure the tracer and instrumentation with these environment variables:
 | `SIGNALFX_TRACING_CLI_ENABLED` | Whether to enable automatic tracer creation and instrumentation for `cli` SAPI. | `false` |
 | `SIGNALFX_TRACE_DEBUG` | Whether to enable debug-level logging. | `false` |
 | `SIGNALFX_DISTRIBUTED_TRACING` | Whether to enable B3 context propagation for applicable client and server libraries. | `true` |
+| `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` | Maximum length an attribute value can have. Values longer than this are truncated. | `1200` |
 
 Because auto-instrumentation is applied during initialization, all configuration
 environment variables MUST be set by launch time. Anything set via `putenv()`

--- a/src/DDTrace/Configuration.php
+++ b/src/DDTrace/Configuration.php
@@ -76,6 +76,19 @@ class Configuration extends AbstractConfiguration
         return (int)$this->floatValue('spans.limit', 1000);
     }
 
+    /**
+     * Maximum size span attribute values can have. Attribute values larger than this size
+     * are truncated to fit the rule.
+     *
+     * -1 means no limit
+     *
+     * @return int
+     */
+    public function getMaxAttributeLength()
+    {
+        return (int)$this->floatValue('recorded.value.max.length', 1200);
+    }
+
 
     /**
      * Whether or not also unfinished spans should be finished (and thus sent) when tracer is flushed.

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -29,6 +29,8 @@ final class Span extends SpanData
         Tag::MANUAL_DROP => true,
     ];
 
+    private $maxAttributeLength;
+
     /**
      * Span constructor.
      * @param string $operationName
@@ -49,6 +51,7 @@ final class Span extends SpanData
         $this->service = (string)$service;
         $this->resource = (string)$resource;
         $this->startTime = $startTime ?: Time::now();
+        $this->maxAttributeLength = Configuration::get()->getMaxAttributeLength();
     }
 
     /**
@@ -188,7 +191,11 @@ final class Span extends SpanData
             }
         }
 
-        $this->tags[$key] = (string)$value;
+        $strValue = (string)$value;
+        if ($this->maxAttributeLength > 0) {
+            $strValue = mb_substr($strValue, 0, $this->maxAttributeLength);
+        }
+        $this->tags[$key] = $strValue;
     }
 
     /**

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -33,6 +33,7 @@ final class ConfigurationTest extends BaseTestCase
         putenv('SIGNALFX_TRACE_ANALYTICS_ENABLED');
         putenv('SIGNALFX_TRACE_DEBUG');
         putenv('SIGNALFX_TRACING_ENABLED');
+        putenv('SIGNALFX_RECORDED_VALUE_MAX_LENGTH');
         putenv('ddtrace_app_name');
     }
 
@@ -160,5 +161,18 @@ final class ConfigurationTest extends BaseTestCase
     {
         putenv('SIGNALFX_TRACE_ANALYTICS_ENABLED=true');
         $this->assertTrue(Configuration::get()->isAnalyticsEnabled());
+    }
+
+    public function testRecordedValueMaxLength()
+    {
+        $this->assertSame(1200, Configuration::get()->getMaxAttributeLength());
+
+        Configuration::clear();
+        putenv('SIGNALFX_RECORDED_VALUE_MAX_LENGTH=strval');
+        $this->assertSame(1200, Configuration::get()->getMaxAttributeLength());
+
+        Configuration::clear();
+        putenv('SIGNALFX_RECORDED_VALUE_MAX_LENGTH=10');
+        $this->assertSame(10, Configuration::get()->getMaxAttributeLength());
     }
 }

--- a/tests/Unit/SpanTest.php
+++ b/tests/Unit/SpanTest.php
@@ -6,6 +6,7 @@ use DDTrace\Span;
 use DDTrace\SpanContext;
 use DDTrace\Tag;
 use DDTrace\Sampling\PrioritySampling;
+use DDTrace\Configuration;
 use DDTrace\GlobalTracer;
 use DDTrace\Tracer;
 use Exception;
@@ -102,6 +103,24 @@ final class SpanTest extends Framework\TestCase
         $span->setTag('foo', new \stdClass());
 
         $this->assertNull($span->getTag('foo'));
+    }
+
+    public function testSpanTagMaxSize()
+    {
+
+        $span = $this->createSpan();
+        $value = "tag value";
+        $span->setTag("t1", $value);
+        $this->assertEquals($span->getTag("t1"), "tag value");
+
+        Configuration::clear();
+        putenv('SIGNALFX_RECORDED_VALUE_MAX_LENGTH=3');
+        $span = $this->createSpan();
+        $value = "tag value";
+        $span->setTag("t1", $value);
+        $this->assertEquals($span->getTag("t1"), "tag");
+        Configuration::clear();
+        putenv('SIGNALFX_RECORDED_VALUE_MAX_LENGTH');
     }
 
     public function testLogWithErrorBoolProperlyMarksError()


### PR DESCRIPTION
SIGNALFX_RECORDED_VALUE_MAX_LENGTH env var allows to set the max size of
attribute values. Any values larger than specified size will be
truncated. Defaults to 1200.

### Readiness checklist
- [x] [Changelog entry](docs/changelog.md) added, if necessary
- [x] Tests added for this feature/bug
