### PR TITLE
Adds support for multiple traceID headers

### DIFF
--- a/src/DDTrace/Propagators/B3CurlHeadersMap.php
+++ b/src/DDTrace/Propagators/B3CurlHeadersMap.php
@@ -84,5 +84,6 @@ final class B3CurlHeadersMap implements Propagator
     public function extract($carrier)
     {
         // This use case is not implemented as we haven't found any framework returning headers in curl style so far.
+        return null;
     }
 }

--- a/src/DDTrace/Propagators/B3TextMap.php
+++ b/src/DDTrace/Propagators/B3TextMap.php
@@ -105,6 +105,7 @@ final class B3TextMap implements Propagator
      * E.g. in both the cases that follow, this method would return 'application/json':
      *   1) as array of values: ['content-type' => ['application/json']]
      *   2) as string value: ['content-type' => 'application/json']
+     *   3) as the last part of string from a comma or semicolor separated string
      *
      * @param array|string $value
      * @return string|null
@@ -114,7 +115,10 @@ final class B3TextMap implements Propagator
         if (is_array($value) && count($value) > 0) {
             return $value[0];
         } elseif (is_string($value)) {
-            return $value;
+            $split = explode(",", $value);
+            $value = end($split);
+            $split = explode(";", $value);
+            return end($split);
         }
         return null;
     }

--- a/src/DDTrace/Propagators/CurlHeadersMap.php
+++ b/src/DDTrace/Propagators/CurlHeadersMap.php
@@ -71,5 +71,6 @@ final class CurlHeadersMap implements Propagator
     public function extract($carrier)
     {
         // This use case is not implemented as we haven't found any framework returning headers in curl style so far.
+        return null;
     }
 }

--- a/src/DDTrace/Propagators/TextMap.php
+++ b/src/DDTrace/Propagators/TextMap.php
@@ -75,6 +75,7 @@ final class TextMap implements Propagator
      * E.g. in both the cases that follow, this method would return 'application/json':
      *   1) as array of values: ['content-type' => ['application/json']]
      *   2) as string value: ['content-type' => 'application/json']
+     *   3) as the last part of string from a comma or semicolor separated string
      *
      * @param array|string $value
      * @return string|null
@@ -84,7 +85,10 @@ final class TextMap implements Propagator
         if (is_array($value) && count($value) > 0) {
             return $value[0];
         } elseif (is_string($value)) {
-            return $value;
+            $split = explode(",", $value);
+            $value = end($split);
+            $split = explode(";", $value);
+            return end($split);
         }
         return null;
     }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -29,7 +29,7 @@ final class Tracer implements TracerInterface
     /**
      * @deprecated Use Tracer::version() instead
      */
-    const VERSION = '0.30.2-beta-sfx2'; // Update ./version.php too
+    const VERSION = '0.30.2-beta-sfx3'; // Update ./version.php too
 
     /**
      * @var Span[][]

--- a/src/DDTrace/version.php
+++ b/src/DDTrace/version.php
@@ -2,4 +2,4 @@
 
 // Must begin with a number for Debian packaging requirements
 // Must use single-quotes for packaging script to work
-return '0.30.2-beta-sfx2'; // Update Tracer::VERSION too
+return '0.30.2-beta-sfx3'; // Update Tracer::VERSION too

--- a/src/ext/version.h
+++ b/src/ext/version.h
@@ -1,3 +1,3 @@
 #ifndef PHP_DDTRACE_VERSION
-#define PHP_DDTRACE_VERSION "0.30.2-beta-sfx2"
+#define PHP_DDTRACE_VERSION "0.30.2-beta-sfx3"
 #endif

--- a/tests/Unit/Propagators/B3TextMapTest.php
+++ b/tests/Unit/Propagators/B3TextMapTest.php
@@ -93,4 +93,29 @@ final class B3TextMapTest extends Framework\TestCase
             ))
         );
     }
+
+    public function testExtractSpanContextFromMultiValueCarrierSuccess()
+    {
+        $carrier = [
+            'x-b3-traceid' => join(",", array("traceid-value", self::TRACE_ID_HEX)),
+            'x-b3-spanid' => join(";", array("spanid-value", self::SPAN_ID_HEX)),
+            'baggage-' . self::BAGGAGE_ITEM_KEY => self::BAGGAGE_ITEM_VALUE,
+        ];
+        $textMapPropagator = new B3TextMap($this->tracer);
+        $context = $textMapPropagator->extract($carrier);
+        $sc = new SpanContext(
+            HexConversion::idToHex(self::TRACE_ID),
+            HexConversion::idToHex(self::SPAN_ID),
+                                null,
+            [self::BAGGAGE_ITEM_KEY => self::BAGGAGE_ITEM_VALUE]
+            );
+        $this->assertTrue(
+            $context->isEqual(new SpanContext(
+                HexConversion::idToHex(self::TRACE_ID),
+                HexConversion::idToHex(self::SPAN_ID),
+                null,
+                [self::BAGGAGE_ITEM_KEY => self::BAGGAGE_ITEM_VALUE]
+            ))
+        );
+    }
 }


### PR DESCRIPTION
Propagators will now correctly extract the last trace or span ID from a
header value if the header contains multipls comma or semi-colon
separated values.
