### PR TITLE
Fix: allow Drupal integration to be loaded with PHP 5 and 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,6 @@ TEST_INTEGRATIONS_56 := \
 	test_integrations_predis1
 
 TEST_WEB_56 := \
-	test_web_drupal_7 \
 	test_web_laravel_42 \
 	test_web_cakephp_28 \
 	test_web_lumen_52 \
@@ -320,6 +319,7 @@ TEST_WEB_56 := \
 	test_web_wordpress_48 \
 	test_web_wordpress_55 \
 	test_web_zend_1 \
+	test_web_drupal_7 \
 	test_web_custom
 
 TEST_INTEGRATIONS_70 := \

--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ TEST_INTEGRATIONS_56 := \
 	test_integrations_predis1
 
 TEST_WEB_56 := \
+	test_web_drupal_7 \
 	test_web_laravel_42 \
 	test_web_cakephp_28 \
 	test_web_lumen_52 \
@@ -319,7 +320,6 @@ TEST_WEB_56 := \
 	test_web_wordpress_48 \
 	test_web_wordpress_55 \
 	test_web_zend_1 \
-	test_web_drupal_7 \
 	test_web_custom
 
 TEST_INTEGRATIONS_70 := \
@@ -467,7 +467,7 @@ TEST_WEB_73 := \
 	test_web_zend_1 \
 	test_web_custom \
 	test_web_drupal_7 \
-	test_web_drupal_89 \
+	test_web_drupal_89
 
 TEST_INTEGRATIONS_74 := \
 	test_integrations_deferred_loading \

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ TEST_WEB_56 := \
 	test_web_wordpress_48 \
 	test_web_wordpress_55 \
 	test_web_zend_1 \
+	test_web_drupal_7 \
 	test_web_custom
 
 TEST_INTEGRATIONS_70 := \
@@ -465,7 +466,8 @@ TEST_WEB_73 := \
 	test_web_yii_2 \
 	test_web_zend_1 \
 	test_web_custom \
-	test_web_drupal_89
+	test_web_drupal_7 \
+	test_web_drupal_89 \
 
 TEST_INTEGRATIONS_74 := \
 	test_integrations_deferred_loading \
@@ -501,6 +503,7 @@ TEST_WEB_74 := \
 	test_web_yii_2 \
 	test_web_zend_1 \
 	test_web_custom \
+	test_web_drupal_7 \
 	test_web_drupal_89
 
 # NOTE: test_integrations_phpredis5 is not included in the PHP 8.0 integrations tests because of this bug that only

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -73,6 +73,8 @@ class IntegrationsLoader
                 '\DDTrace\Integrations\Mysqli\MysqliIntegration';
             $this->integrations[SymfonyIntegration::NAME] =
                 '\DDTrace\Integrations\Symfony\SymfonyIntegration';
+            $this->integrations[DrupalIntegration::NAME] =
+                '\DDTrace\Integrations\Drupal\DrupalIntegration';
             return;
         }
 

--- a/src/DDTrace/Integrations/IntegrationsLoader.php
+++ b/src/DDTrace/Integrations/IntegrationsLoader.php
@@ -96,11 +96,8 @@ class IntegrationsLoader
             '\DDTrace\Integrations\Symfony\SymfonyIntegration';
         $this->integrations[ZendFrameworkIntegration::NAME] =
             '\DDTrace\Integrations\ZendFramework\ZendFrameworkIntegration';
-
-        if (\PHP_MAJOR_VERSION == 7) {
-            $this->integrations[DrupalIntegration::NAME] =
-                '\DDTrace\Integrations\Drupal\DrupalIntegration';
-        }
+        $this->integrations[DrupalIntegration::NAME] =
+            '\DDTrace\Integrations\Drupal\DrupalIntegration';
 
         // For PHP 7.0+ use C level deferred integration loader
         if (\PHP_MAJOR_VERSION < 7) {

--- a/tests/Integrations/Drupal/V7/CommonScenariosTest.php
+++ b/tests/Integrations/Drupal/V7/CommonScenariosTest.php
@@ -91,7 +91,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                                     [
                                         SpanAssertion::exists('module_invoke', 'system_cron')->withChildren(array_merge(
                                             array_fill(0, 15, SpanAssertion::exists('PDO.prepare')),
-                                            array_fill(0, 15, SpanAssertion::exists('PDOStatement.execute')),
+                                            array_fill(0, 15, SpanAssertion::exists('PDOStatement.execute'))
                                         )),
                                         SpanAssertion::exists('module_invoke', 'search_cron')->withChildren([
                                             SpanAssertion::exists('PDO.prepare'),
@@ -103,7 +103,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                                         ]),
                                         SpanAssertion::exists('module_invoke', 'field_cron')->withChildren(array_merge(
                                             array_fill(0, 11, SpanAssertion::exists('PDO.prepare')),
-                                            array_fill(0, 11, SpanAssertion::exists('PDOStatement.execute')),
+                                            array_fill(0, 11, SpanAssertion::exists('PDOStatement.execute'))
                                         )),
                                         SpanAssertion::exists('module_invoke', 'dblog_cron')->withChildren([
                                             SpanAssertion::exists('PDO.prepare'),

--- a/tests/Unit/Integrations/IntegrationsLoaderTest.php
+++ b/tests/Unit/Integrations/IntegrationsLoaderTest.php
@@ -157,7 +157,6 @@ final class IntegrationsLoaderTest extends BaseTestCase
         $excluded = [];
         if (\PHP_MAJOR_VERSION < 7) {
             $excluded[] = 'phpredis'; // PHP 7 only integration
-            $excluded[] = 'drupal';
         } else {
             // Deferred loading integrations
             $excluded[] = 'elasticsearch';
@@ -175,7 +174,6 @@ final class IntegrationsLoaderTest extends BaseTestCase
             $excluded[] = 'lumen';
             $excluded[] = 'mongo';
             $excluded[] = 'zendframework';
-            $excluded[] = 'drupal';
         }
         foreach ($excluded as $integrationToExclude) {
             $index = array_search($integrationToExclude, $expected, true);


### PR DESCRIPTION
Drupal integration failed to load on PHP 5, removed the check for PHP 7.

Also:
* Enabled Drupal 7 tests for PHP 7.3, 7.4 and 5.6
* Made the test PHP file compatible with PHP 5 syntax