### PR TITLE
trace file_get_contents, json_encode, json_decode

### DIFF
--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -435,3 +435,13 @@ function sfx_trace_config_drupal_rename_span()
 {
     return _ddtrace_config_bool(\getenv('SIGNALFX_DRUPAL_RENAME_ROOT_SPAN'), true);
 }
+
+function sfx_trace_config_trace_json()
+{
+    return _ddtrace_config_bool(\getenv('SIGNALFX_TRACE_JSON'), false);
+}
+
+function sfx_trace_config_trace_file_get_contents()
+{
+    return _ddtrace_config_bool(\getenv('SIGNALFX_TRACE_FILE_GET_CONTENTS'), false);
+}

--- a/ext/php7/handlers_internal.c
+++ b/ext/php7/handlers_internal.c
@@ -129,6 +129,9 @@ void ddtrace_internal_handlers_startup(void) {
     ddtrace_string handlers[] = {
         DDTRACE_STRING_LITERAL("header"),
         DDTRACE_STRING_LITERAL("http_response_code"),
+        DDTRACE_STRING_LITERAL("file_get_contents"),
+        DDTRACE_STRING_LITERAL("json_encode"),
+        DDTRACE_STRING_LITERAL("json_decode"),
     };
     size_t handlers_len = sizeof handlers / sizeof handlers[0];
     ddtrace_replace_internal_functions(CG(function_table), handlers_len, handlers);

--- a/ext/php8/handlers_internal.c
+++ b/ext/php8/handlers_internal.c
@@ -129,6 +129,9 @@ void ddtrace_internal_handlers_startup(void) {
     ddtrace_string handlers[] = {
         DDTRACE_STRING_LITERAL("header"),
         DDTRACE_STRING_LITERAL("http_response_code"),
+        DDTRACE_STRING_LITERAL("file_get_contents"),
+        DDTRACE_STRING_LITERAL("json_encode"),
+        DDTRACE_STRING_LITERAL("json_decode"),
     };
     size_t handlers_len = sizeof handlers / sizeof handlers[0];
     ddtrace_replace_internal_functions(CG(function_table), handlers_len, handlers);

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -168,6 +168,30 @@ final class Bootstrap
                 $rootSpan->setTag(Tag::HTTP_STATUS_CODE, $code);
             }
         });
+
+        if (\sfx_trace_config_trace_file_get_contents()) {
+            \DDTrace\trace_function('file_get_contents', function (SpanData $span, $args, $result) {
+                $span->name = 'file_get_contents';
+                $span->meta['file.name'] = $args[0];
+                if ($result === false) {
+                    $span->meta[Tag::ERROR] = 'true';
+                    $err = \error_get_last();
+                    if ($err) {
+                        $span->meta[Tag::ERROR_MSG] = $err['message'];
+                    }
+                }
+            });
+        }
+
+        if (\sfx_trace_config_trace_json()) {
+            \DDTrace\trace_function('json_encode', function (SpanData $span) {
+                $span->name = 'json_encode';
+            });
+
+            \DDTrace\trace_function('json_decode', function (SpanData $span) {
+                $span->name = 'json_decode';
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
2 new env variables, both defaulting to `false`:
- `SIGNALFX_TRACE_JSON`: trace `json_encode` and `json_decode`
- `SIGNALFX_TRACE_FILE_GET_CONTENTS`: trace `file_get_contents`, if an error happens add it as a tag if possible