### PR TITLE
feat: capture request headers

### DIFF
--- a/bridge/configuration.php
+++ b/bridge/configuration.php
@@ -455,3 +455,14 @@ function sfx_trace_config_capture_env_vars()
     }
     return $normalized;
 }
+
+function sfx_trace_config_capture_request_headers()
+{
+    $to_capture = _ddtrace_config_indexed_array(\getenv('SIGNALFX_CAPTURE_REQUEST_HEADERS'), []);
+    $normalized = [];
+    foreach ($to_capture as $key) {
+        $php_key = 'HTTP_' . str_replace('-', '_', strtoupper($key));
+        $normalized[$php_key] = 'http.request.header.' . str_replace('-', '_', strtolower($key));
+    }
+    return $normalized;
+}

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -199,6 +199,13 @@ final class Bootstrap
                 $rootSpan->setTag($normalized_key, $val);
             }
         }
+
+        foreach (\sfx_trace_config_capture_request_headers() as $key => $tag) {
+            $val = $_SERVER[$key];
+            if (!is_null($val)) {
+                $rootSpan->setTag($tag, $val);
+            }
+        }
     }
 
     /**

--- a/src/DDTrace/Bootstrap.php
+++ b/src/DDTrace/Bootstrap.php
@@ -201,9 +201,8 @@ final class Bootstrap
         }
 
         foreach (\sfx_trace_config_capture_request_headers() as $key => $tag) {
-            $val = $_SERVER[$key];
-            if (!is_null($val)) {
-                $rootSpan->setTag($tag, $val);
+            if (!empty($_SERVER[$key])) {
+                $rootSpan->setTag($tag, $_SERVER[$key]);
             }
         }
     }

--- a/tests/Integration/RequestHeaderCaptureTest.php
+++ b/tests/Integration/RequestHeaderCaptureTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace DDTrace\Tests\Integration;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+class RequestHeaderCaptureTest extends WebFrameworkTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/ResponseStatusCodeTest_files/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_TRACE_NO_AUTOLOADER' => '1',
+            'SIGNALFX_CAPTURE_REQUEST_HEADERS' => 'X-Foo',
+        ]);
+    }
+
+    public function testCapture()
+    {
+        $traces = $this->tracesFromWebRequest(
+            function () {
+                $headers = array(
+                    'X-Foo' => '42',
+                );
+                $this->call(GetSpec::create('Root', '/success', $headers));
+            }
+        );
+
+        $this->assertExpectedSpans(
+            $traces,
+            [
+                SpanAssertion::build('web.request', 'unnamed-php-service', '', 'GET /success')->withExactTags([
+                    'http.method' => 'GET',
+                    'http.url' => '/success',
+                    'http.status_code' => '200',
+                    'component' => 'web.request',
+                    'http.request.header.x_foo' => '42',
+                ]),
+            ]
+        );
+    }
+}

--- a/tests/Integration/RequestHeaderCaptureTest.php
+++ b/tests/Integration/RequestHeaderCaptureTest.php
@@ -27,8 +27,6 @@ class RequestHeaderCaptureTest extends WebFrameworkTestCase
             function () {
                 $this->call(GetSpec::create('Root', '/success', [
                     'X-Foo: 42',
-                    'X-Foo: abc',
-                    'Content-Type: application/whatever'
                 ]));
             }
         );
@@ -41,8 +39,7 @@ class RequestHeaderCaptureTest extends WebFrameworkTestCase
                     'http.url' => '/success',
                     'http.status_code' => '200',
                     'component' => 'web.request',
-                    'http.request.header.x_foo' => '42, abc',
-                    'http.request.header.content_type' => 'application/whatever',
+                    'http.request.header.x_foo' => '42',
                 ]),
             ]
         );

--- a/tests/Integration/RequestHeaderCaptureTest.php
+++ b/tests/Integration/RequestHeaderCaptureTest.php
@@ -25,10 +25,11 @@ class RequestHeaderCaptureTest extends WebFrameworkTestCase
     {
         $traces = $this->tracesFromWebRequest(
             function () {
-                $headers = array(
-                    'X-Foo' => '42',
-                );
-                $this->call(GetSpec::create('Root', '/success', $headers));
+                $this->call(GetSpec::create('Root', '/success', [
+                    'X-Foo: 42',
+                    'X-Foo: abc',
+                    'Content-Type: application/whatever'
+                ]));
             }
         );
 
@@ -40,7 +41,8 @@ class RequestHeaderCaptureTest extends WebFrameworkTestCase
                     'http.url' => '/success',
                     'http.status_code' => '200',
                     'component' => 'web.request',
-                    'http.request.header.x_foo' => '42',
+                    'http.request.header.x_foo' => '42, abc',
+                    'http.request.header.content_type' => 'application/whatever',
                 ]),
             ]
         );


### PR DESCRIPTION
- new env var: `SIGNALFX_CAPTURE_REQUEST_HEADERS`, comma separated list of headers to capture
- headers are attached to the root span as `http.request.header.header_name`