### PR TITLE
Refork - enable SIGNALFX config prefix, use sfx endpoint configuration

### DIFF
--- a/ext/php7/configuration.c
+++ b/ext/php7/configuration.c
@@ -91,6 +91,10 @@ static void dd_ini_env_to_ini_name(const zai_string_view env_name, zai_config_na
         if (env_name.ptr == strstr(env_name.ptr, "DD_TRACE_")) {
             ini_name->ptr[sizeof("datadog.trace") - 1] = '.';
         }
+    } else if (env_name.ptr == strstr(env_name.ptr, "SIGNALFX_")) {
+        dd_copy_tolower(ini_name->ptr, env_name.ptr);
+        ini_name->ptr[sizeof("signalfx") - 1] = '.';
+        ini_name->len = env_name.len;
     } else {
         ini_name->len = 0;
         assert(false && "Unexpected env var name: missing 'DD_' prefix");

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -59,6 +59,13 @@ extern bool runtime_config_first_init;
 #define DD_CONFIGURATION                                                                                       \
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
+    CONFIG(BOOL, SIGNALFX_MODE, "false")                                                                       \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_URL, "")                                                                  \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_HOST, "localhost")                                                        \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_PORT, "9080")                                                             \
+    CONFIG(BOOL, SIGNALFX_ENDPOINT_HTTPS, "false")                                                             \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_PATH, "/v1/trace")                                                        \
+    CONFIG(STRING, SIGNALFX_ACCESS_TOKEN, "")                                                                  \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                         \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                              \
     CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \

--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -183,6 +183,11 @@ static size_t _dd_curl_write_noop(void *ptr, size_t size, size_t nmemb, void *us
 }
 
 static size_t _dd_check_for_agent_error(char *error, bool quick) {
+    if (get_global_SIGNALFX_MODE()) {
+        error[0] = 0;
+        return 0;
+    }
+
     CURL *curl = curl_easy_init();
     ddtrace_curl_set_hostname(curl);
     if (quick) {

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -666,6 +666,15 @@ static void dd_append_header(struct curl_slist **list, const char *key, const ch
 static struct curl_slist *dd_agent_headers_alloc(void) {
     struct curl_slist *list = NULL;
 
+    if (get_global_SIGNALFX_MODE()) {
+        zend_string *access_token = get_global_SIGNALFX_ACCESS_TOKEN();
+        if (ZSTR_LEN(access_token) > 0) {
+            dd_append_header(&list, "X-SF-Token", ZSTR_VAL(access_token));
+        }
+        // avoid wrapping dd code in else to prevent merge conflicts
+        goto skip_dd_headers;
+    }
+
     dd_append_header(&list, "Datadog-Meta-Lang", "php");
     dd_append_header(&list, "Datadog-Meta-Lang-Interpreter", sapi_module.name);
     dd_append_header(&list, "Datadog-Meta-Lang-Version", PHP_VERSION);
@@ -680,6 +689,7 @@ static struct curl_slist *dd_agent_headers_alloc(void) {
      * wait for *1 second* for 100 Continue response before sending the rest of the data. This wait is
      * configurable, but requires a newer curl than we have on CentOS 6. So instead we send an empty Expect.
      */
+    skip_dd_headers:
     dd_append_header(&list, "Expect", "");
 
     return list;
@@ -705,7 +715,27 @@ void ddtrace_curl_set_connect_timeout(CURL *curl) {
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, timeout);
 }
 
+char *signalfx_agent_url(void) {
+    zend_string *url = get_global_SIGNALFX_ENDPOINT_URL();
+    if (ZSTR_LEN(url) > 0) {
+        return zend_strndup(ZSTR_VAL(url), ZSTR_LEN(url));
+    }
+
+    bool is_https = get_global_SIGNALFX_ENDPOINT_HTTPS();
+    zend_string *host = get_global_SIGNALFX_ENDPOINT_HOST();
+    zend_string *port = get_global_SIGNALFX_ENDPOINT_PORT();
+    zend_string *path = get_global_SIGNALFX_ENDPOINT_PATH();
+    char *formatted_url;
+    asprintf(&formatted_url, "%s%s:%s%s", is_https ? "https://" : "http://", ZSTR_VAL(host), ZSTR_VAL(port), 
+             ZSTR_VAL(path));
+    return formatted_url;
+}
+
 char *ddtrace_agent_url(void) {
+    if (get_global_SIGNALFX_MODE()) {
+        return signalfx_agent_url();
+    }
+
     zend_string *url = get_global_DD_TRACE_AGENT_URL();
     if (ZSTR_LEN(url) > 0) {
         return zend_strndup(ZSTR_VAL(url), ZSTR_LEN(url));
@@ -741,7 +771,9 @@ char *ddtrace_agent_url(void) {
 
 void ddtrace_curl_set_hostname(CURL *curl) {
     char *url = ddtrace_agent_url();
-    if (url && url[0]) {
+    if (get_global_SIGNALFX_MODE()) {
+        curl_easy_setopt(curl, CURLOPT_URL, url);
+    } else if (url && url[0]) {
         char *http_url = url;
         if (strlen(url) > 7 && strncmp(url, "unix://", 7) == 0) {
             curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, url + 7);
@@ -797,12 +829,17 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
     headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
     headers = curl_slist_append(headers, "Content-Type: application/msgpack");
 
+    if (get_global_SIGNALFX_MODE()) {
+        goto skip_dd_headers;
+    }
+
     char buffer[64];
     int bytes_written = snprintf(buffer, sizeof buffer, DD_TRACE_COUNT_HEADER "%zu", trace_count);
     if (bytes_written > ((int)sizeof(DD_TRACE_COUNT_HEADER)) - 1 && bytes_written < ((int)sizeof buffer)) {
         headers = curl_slist_append(headers, buffer);
     }
 
+    skip_dd_headers:
     _dd_curl_reset_headers(writer);
 
     curl_easy_setopt(writer->curl, CURLOPT_HTTPHEADER, headers);
@@ -826,6 +863,7 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         ddtrace_curl_set_connect_timeout(writer->curl);
 
         curl_easy_setopt(writer->curl, CURLOPT_UPLOAD, 1);
+        curl_easy_setopt(writer->curl, CURLOPT_POST, 1);
         curl_easy_setopt(writer->curl, CURLOPT_VERBOSE, get_global_DD_TRACE_AGENT_DEBUG_VERBOSE_CURL());
 
         res = curl_easy_perform(writer->curl);

--- a/ext/php8/configuration.c
+++ b/ext/php8/configuration.c
@@ -91,6 +91,10 @@ static void dd_ini_env_to_ini_name(const zai_string_view env_name, zai_config_na
         if (env_name.ptr == strstr(env_name.ptr, "DD_TRACE_")) {
             ini_name->ptr[sizeof("datadog.trace") - 1] = '.';
         }
+    } else if (env_name.ptr == strstr(env_name.ptr, "SIGNALFX_")) {
+        dd_copy_tolower(ini_name->ptr, env_name.ptr);
+        ini_name->ptr[sizeof("signalfx") - 1] = '.';
+        ini_name->len = env_name.len;
     } else {
         ini_name->len = 0;
         assert(false && "Unexpected env var name: missing 'DD_' prefix");

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -59,6 +59,13 @@ extern bool runtime_config_first_init;
 #define DD_CONFIGURATION                                                                                       \
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
+    CONFIG(BOOL, SIGNALFX_MODE, "false")                                                                       \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_URL, "")                                                                  \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_HOST, "localhost")                                                        \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_PORT, "9080")                                                             \
+    CONFIG(BOOL, SIGNALFX_ENDPOINT_HTTPS, "false")                                                             \
+    CONFIG(STRING, SIGNALFX_ENDPOINT_PATH, "/v1/trace")                                                        \
+    CONFIG(STRING, SIGNALFX_ACCESS_TOKEN, "")                                                                  \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                         \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                              \
     CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \

--- a/ext/php8/startup_logging.c
+++ b/ext/php8/startup_logging.c
@@ -183,6 +183,11 @@ static size_t _dd_curl_write_noop(void *ptr, size_t size, size_t nmemb, void *us
 }
 
 static size_t _dd_check_for_agent_error(char *error, bool quick) {
+    if (get_global_SIGNALFX_MODE()) {
+        error[0] = 0;
+        return 0;
+    }
+
     CURL *curl = curl_easy_init();
     ddtrace_curl_set_hostname(curl);
     if (quick) {

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -69,18 +69,70 @@ static void zai_config_copy_name(zai_config_name *dest, zai_string_view src) {
     dest->len = src.len;
 }
 
+static void signalfx_memoize_alternate_name(zai_config_memoized_entry *memoized, zai_string_view *name,
+                                            zai_string_view dd_name, zai_string_view sfx_name) {
+    if (memoized->names_count >= ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX) {
+        return;
+    } else if (name->len != dd_name.len || strncmp(name->ptr, dd_name.ptr, name->len) != 0) {
+        return;
+    }
+
+    zai_config_name *dest = &memoized->names[memoized->names_count++];
+    zai_config_copy_name(dest, sfx_name);
+}
+
+static void signalfx_memoize_alternate_prefix(zai_config_memoized_entry *memoized, 
+                                              zai_string_view *name, zai_string_view dd_prefix, 
+                                              zai_string_view sfx_prefix) {
+    if (memoized->names_count >= ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX) {
+        return;
+    } else if (name->len <= dd_prefix.len || strncmp(name->ptr, dd_prefix.ptr, dd_prefix.len) != 0) {
+        return;
+    }
+
+    size_t new_length = name->len - dd_prefix.len + sfx_prefix.len;
+    assert((new_length  < ZAI_CONFIG_NAME_BUFSIZ) && "SignalFX name length greater than the buffer size");
+
+    zai_config_name *dest = &memoized->names[memoized->names_count++];
+    strncpy(dest->ptr, sfx_prefix.ptr, sfx_prefix.len);
+    strncpy(&dest->ptr[sfx_prefix.len], &name->ptr[dd_prefix.len], name->len - dd_prefix.len);
+    dest->len = new_length;
+}
+
+static void signalfx_memoize_alternates_names(zai_config_memoized_entry *memoized, zai_string_view *name, bool is_main) {
+    if (is_main) {
+        signalfx_memoize_alternate_name(memoized, name, ZAI_STRL_VIEW("DD_TRACE_ENABLED"), 
+                                        ZAI_STRL_VIEW("SIGNALFX_TRACING_ENABLED"));
+    }
+
+    signalfx_memoize_alternate_prefix(memoized, name, ZAI_STRL_VIEW("DD_"), ZAI_STRL_VIEW("SIGNALFX_"));
+}
+
+static void signalfx_memoize_entry_alternate_names(zai_config_memoized_entry *memoized, zai_config_entry *entry) {
+    memoized->names_count = 0;
+
+    signalfx_memoize_alternates_names(memoized, &entry->name, true);
+
+    for (uint8_t i = 0; i < entry->aliases_count; i++) {
+        signalfx_memoize_alternates_names(memoized, &entry->aliases[i], false);
+    }
+}
+
 static zai_config_memoized_entry *zai_config_memoize_entry(zai_config_entry *entry) {
     assert((entry->id < ZAI_CONFIG_ENTRIES_COUNT_MAX) && "Out of bounds config entry ID");
     assert((entry->aliases_count < ZAI_CONFIG_NAMES_COUNT_MAX) &&
            "Number of aliases + name are greater than ZAI_CONFIG_NAMES_COUNT_MAX");
 
     zai_config_memoized_entry *memoized = &zai_config_memoized_entries[entry->id];
+    signalfx_memoize_entry_alternate_names(memoized, entry);
 
-    zai_config_copy_name(&memoized->names[0], entry->name);
+    uint8_t names_start_index = memoized->names_count;
+
+    zai_config_copy_name(&memoized->names[names_start_index], entry->name);
     for (uint8_t i = 0; i < entry->aliases_count; i++) {
-        zai_config_copy_name(&memoized->names[i + 1], entry->aliases[i]);
+        zai_config_copy_name(&memoized->names[names_start_index + i + 1], entry->aliases[i]);
     }
-    memoized->names_count = entry->aliases_count + 1;
+    memoized->names_count += entry->aliases_count + 1;
 
     memoized->type = entry->type;
     memoized->default_encoded_value = entry->default_encoded_value;

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -19,6 +19,8 @@ typedef uint16_t zai_config_id;
 
 #define ZAI_CONFIG_ENTRIES_COUNT_MAX 160
 #define ZAI_CONFIG_NAMES_COUNT_MAX 4
+#define ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX (ZAI_CONFIG_NAMES_COUNT_MAX + 1)
+#define ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX (ZAI_CONFIG_NAMES_COUNT_MAX + ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX)
 #define ZAI_CONFIG_NAME_BUFSIZ 60
 
 #define ZAI_CONFIG_ENTRY(_id, _name, _type, default, ...)                          \
@@ -52,8 +54,8 @@ struct zai_config_name_s {
 };
 
 struct zai_config_memoized_entry_s {
-    zai_config_name names[ZAI_CONFIG_NAMES_COUNT_MAX];
-    zend_ini_entry *ini_entries[ZAI_CONFIG_NAMES_COUNT_MAX];
+    zai_config_name names[ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX];
+    zend_ini_entry *ini_entries[ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX];
     uint8_t names_count;
     zai_config_type type;
     zval decoded_value;

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -234,7 +234,7 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
 }
 
 // PHP 5 expects 'static storage duration for ini entry names
-zai_config_name ini_names[ZAI_CONFIG_ENTRIES_COUNT_MAX * ZAI_CONFIG_NAMES_COUNT_MAX];
+zai_config_name ini_names[ZAI_CONFIG_ENTRIES_COUNT_MAX * ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX];
 
 void zai_config_ini_minit(zai_config_env_to_ini_name env_to_ini, int module_number) {
     env_to_ini_name = env_to_ini;
@@ -246,7 +246,7 @@ void zai_config_ini_minit(zai_config_env_to_ini_name env_to_ini, int module_numb
     for (zai_config_id i = 0; i < zai_config_memoized_entries_count; ++i) {
         zai_config_memoized_entry *memoized = &zai_config_memoized_entries[i];
         for (uint8_t n = 0; n < memoized->names_count; ++n) {
-            zai_config_name *ini_name = &ini_names[i * ZAI_CONFIG_NAMES_COUNT_MAX + n];
+            zai_config_name *ini_name = &ini_names[i * ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX + n];
             zai_string_view name = {.len = memoized->names[n].len, .ptr = memoized->names[n].ptr};
             zai_config_add_ini_entry(memoized, name, ini_name, module_number, i);
             // We need to cache ini directives here, at least for ZTS in order to access the global inis


### PR DESCRIPTION
This is the first PR to the reforked upstream. The plan is to swap the refork branch with main branch once the reforked version is complete enough to be released.

- Allows the use of `SIGNALFX_` prefix for ALL configuration options (and they have priority over DD_ prefix ones)
- Adds `SIGNALFX_MODE` configuration option which enables all SignalFX specific code. This is necessary because in order to avoid having to rewrite tests completely (as they depend on certain structure of the data that will be changed in SFX exporter), so we can have most tests have this disabled. The plan is to make this default to `true` later so it would not be possible for a customer to accidentally not have it enabled.
- Initial configuration to make the SignalFX endpoint configuration options work. This does not yet implement sending Zipkin, so it is simply a partial implementation so far - just uses SFX conf options, removes DataDog specific headers, removes endpoint probing, uses `POST` instead of `PUT`, and includes access token header if specified. Not actually usable until the MessagePack to Zipkin converter is added before payload queueing.

Some remarks about code style - currently decided to use `goto` in a few places for a very specific reason - to avoid reindenting code that doesn't require any changes, so that future syncing would produce less conflicts.