### PR TITLE
Refork - send JSON to endpoint, add markers to all places with SFX specific code

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -165,6 +165,7 @@ if test "$PHP_DDTRACE" != "no"; then
       zend_abstract_interface/interceptor/php8/interceptor.c \
       zend_abstract_interface/interceptor/php8/resolver.c \
       zend_abstract_interface/json/json.c \
+      zend_abstract_interface/signalfx/json_writer.c \
       zend_abstract_interface/symbols/lookup.c \
       zend_abstract_interface/symbols/call.c \
       zend_abstract_interface/sandbox/php8/sandbox.c \

--- a/ext/php7/comms_php.h
+++ b/ext/php7/comms_php.h
@@ -10,5 +10,7 @@
 static const size_t AGENT_REQUEST_BODY_LIMIT = 10485760;
 
 bool ddtrace_send_traces_via_thread(size_t num_traces, char *payload, size_t payload_len);
+// SIGNALFX: single trace sender, see implementation
+bool ddtrace_send_trace_via_thread(char *payload, size_t payload_len);
 
 #endif  // DDTRACE_COMMS_PHP_H

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -476,9 +476,12 @@ static size_t _dd_coms_read_callback(char *buffer, size_t size, size_t nitems, v
     size_t written = 0;
     size_t buffer_size = size * nitems;
 
-    if (read->total_groups > 0) {
-        written += _dd_write_array_header(buffer, buffer_size, written, read->total_groups);
-        read->total_groups = 0;
+    // SIGNALFX: using JSON payload, so the msgpack array header is not required
+    if (!get_global_SIGNALFX_MODE()) {
+        if (read->total_groups > 0) {
+            written += _dd_write_array_header(buffer, buffer_size, written, read->total_groups);
+            read->total_groups = 0;
+        }
     }
 
     // write the remainder from previous iteration
@@ -567,6 +570,12 @@ static void _dd_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _g
     dest->total_groups++;
     size_t current_src_beginning = 0, next_src_beginning = 0, group_dest_beginning_position = 0;
 
+    // SIGNALFX: using JSON instead of msgpack, therefore the separate arrays in each entry need to be
+    // concatenated - these variables track the state for doing that
+    bool flattened_json = get_global_SIGNALFX_MODE();
+    size_t entries_copied = 0;
+    size_t last_entry_comma_position = 0;
+
     size_t bytes_written = atomic_load(&stack->bytes_written);
 
     while (current_src_beginning < bytes_written) {
@@ -592,6 +601,17 @@ static void _dd_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _g
                     elements_in_group++;
                     group_dest_position += copied;
                     bytes_in_group += copied;
+
+                    // SIGNALFX: concatenate JSON arrays by replacing the end ] with comma, and the begin [
+                    // with a space for entries beyond first one
+                    if (flattened_json) {
+                        dest->dest_data[group_dest_position - 1] = ',';
+                        last_entry_comma_position = group_dest_position - 1;
+                        if (entries_copied > 0) {
+                            dest->dest_data[group_dest_position - copied] = ' ';
+                        }
+                        entries_copied++;
+                    }
                 }
             } else if (next_group_entry.group_id == current_group_id && entry.group_id != GROUP_ID_PROCESSED) {
                 dest->total_groups++;  // add unique group count
@@ -611,6 +631,12 @@ static void _dd_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _g
 
         current_group_id = next_group_entry.group_id;
         current_src_beginning = next_src_beginning;
+    }
+    // SIGNALFX: replace the last comma with ] to end the JSON array properly
+    if (flattened_json) {
+        if (last_entry_comma_position > 0) {
+            dest->dest_data[last_entry_comma_position] = ']';
+        }
     }
     dest->total_bytes = group_dest_beginning_position;  // save total bytes count after conversion
 }
@@ -672,6 +698,7 @@ static void dd_append_header(struct curl_slist **list, const char *key, const ch
 static struct curl_slist *dd_agent_headers_alloc(void) {
     struct curl_slist *list = NULL;
 
+    // SIGNALFX: add access token header and skip DD specific headers
     if (get_global_SIGNALFX_MODE()) {
         zend_string *access_token = get_global_SIGNALFX_ACCESS_TOKEN();
         if (ZSTR_LEN(access_token) > 0) {
@@ -721,6 +748,7 @@ void ddtrace_curl_set_connect_timeout(CURL *curl) {
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, timeout);
 }
 
+// SIGNALFX: endpoint configuration for SignalFX uses different configuration options and includes path part
 char *signalfx_agent_url(void) {
     zend_string *url = get_global_SIGNALFX_ENDPOINT_URL();
     if (ZSTR_LEN(url) > 0) {
@@ -738,6 +766,7 @@ char *signalfx_agent_url(void) {
 }
 
 char *ddtrace_agent_url(void) {
+    // SIGNALFX: use SignalFX specific configuration options for endpoint URL
     if (get_global_SIGNALFX_MODE()) {
         return signalfx_agent_url();
     }
@@ -777,6 +806,7 @@ char *ddtrace_agent_url(void) {
 
 void ddtrace_curl_set_hostname(CURL *curl) {
     char *url = ddtrace_agent_url();
+    // SIGNALFX: SignalFX url already contains the path part, skip adding that
     if (get_global_SIGNALFX_MODE()) {
         curl_easy_setopt(curl, CURLOPT_URL, url);
     } else if (url && url[0]) {
@@ -835,9 +865,13 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
     headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
     headers = curl_slist_append(headers, "Content-Type: application/msgpack");
 
+    // SIGNALFX: sending JSON data, so set the content type to JSON instead of msgpack and skip DD specific headers
     if (get_global_SIGNALFX_MODE()) {
+        headers = curl_slist_append(headers, "Content-Type: application/json");
         goto skip_dd_headers;
     }
+
+    headers = curl_slist_append(headers, "Content-Type: application/msgpack");
 
     char buffer[64];
     int bytes_written = snprintf(buffer, sizeof buffer, DD_TRACE_COUNT_HEADER "%zu", trace_count);
@@ -869,6 +903,8 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         ddtrace_curl_set_connect_timeout(writer->curl);
 
         curl_easy_setopt(writer->curl, CURLOPT_UPLOAD, 1);
+        // SIGNALFX: use POST instead of PUT for the upload
+        curl_easy_setopt(writer->curl, CURLOPT_PUT, 1);
         curl_easy_setopt(writer->curl, CURLOPT_POST, 1);
         curl_easy_setopt(writer->curl, CURLOPT_VERBOSE, get_global_DD_TRACE_AGENT_DEBUG_VERBOSE_CURL());
 

--- a/ext/php7/configuration.c
+++ b/ext/php7/configuration.c
@@ -92,6 +92,7 @@ static void dd_ini_env_to_ini_name(const zai_string_view env_name, zai_config_na
             ini_name->ptr[sizeof("datadog.trace") - 1] = '.';
         }
     } else if (env_name.ptr == strstr(env_name.ptr, "SIGNALFX_")) {
+        // SIGNALFX: allow SIGNALFX_ prefix for configuration options
         dd_copy_tolower(ini_name->ptr, env_name.ptr);
         ini_name->ptr[sizeof("signalfx") - 1] = '.';
         ini_name->len = env_name.len;

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -59,6 +59,7 @@ extern bool runtime_config_first_init;
 #define DD_CONFIGURATION                                                                                       \
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
+    /* SIGNALFX: add SignalFX specific configuration options */                                                \
     CONFIG(BOOL, SIGNALFX_MODE, "false")                                                                       \
     CONFIG(STRING, SIGNALFX_ENDPOINT_URL, "")                                                                  \
     CONFIG(STRING, SIGNALFX_ENDPOINT_HOST, "localhost")                                                        \

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -26,6 +26,7 @@
 #include "mpack/mpack.h"
 #include "priority_sampling/priority_sampling.h"
 #include "runtime.h"
+#include "signalfx/json_writer.h"
 #include "span.h"
 #include "uri_normalization.h"
 
@@ -139,6 +140,132 @@ int ddtrace_serialize_simple_array_into_c_string(zval *trace, char **data_p, siz
     // finish writing
     if (mpack_writer_destroy(&writer) != mpack_ok) {
         free(data);
+        return 0;
+    }
+
+    if (data_p && size_p) {
+        *data_p = data;
+        *size_p = size;
+
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+static int json_write_zval(json_writer_s *writer, zval *trace, int level);
+
+// SIGNALFX: JSON equivalent for msgpack write_hash_table, additionally it does
+// not change trace/span IDs to number types as is done for msgpack
+static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level) {
+    zval *tmp;
+    zend_string *string_key;
+    zend_long num_key;
+    bool is_assoc = 0;
+
+#if PHP_VERSION_ID >= 80100
+    is_assoc = !zend_array_is_list(ht);
+#else
+    Bucket *bucket;
+    ZEND_HASH_FOREACH_BUCKET(ht, bucket) { is_assoc = is_assoc || bucket->key != NULL; }
+    ZEND_HASH_FOREACH_END();
+#endif
+
+    if (is_assoc) {
+        json_writer_object_begin(writer);
+    } else {
+        json_writer_array_begin(writer);
+    }
+
+    bool is_first = true;
+
+    ZEND_HASH_FOREACH_KEY_VAL_IND(ht, num_key, string_key, tmp) {
+        if (is_first) {
+            is_first = false;    
+        } else {
+            json_writer_element_separator(writer);
+        }
+
+        // Writing the key, if associative
+        if (is_assoc == 1) {
+            char num_str_buf[MAX_ID_BUFSIZ], *key;
+            if (string_key) {
+                key = ZSTR_VAL(string_key);
+            } else {
+                key = num_str_buf;
+                sprintf(num_str_buf, ZEND_LONG_FMT, num_key);
+            }
+            json_writer_utf8(writer, key);
+            json_writer_key_value_separator(writer);
+        }
+
+        // Writing the value
+        if (json_write_zval(writer, tmp, level) != 1) {
+            return 0;
+        }
+    }
+    ZEND_HASH_FOREACH_END();
+
+    if (is_assoc) {
+        json_writer_object_end(writer);
+    } else {
+        json_writer_array_end(writer);
+    }
+    return 1;
+}
+
+// SIGNALFX: JSON equivalent for msgpack msgpack_write_zval
+static int json_write_zval(json_writer_s *writer, zval *trace, int level) {
+    if (Z_TYPE_P(trace) == IS_REFERENCE) {
+        trace = Z_REFVAL_P(trace);
+    }
+
+    switch (Z_TYPE_P(trace)) {
+        case IS_ARRAY:
+            if (json_write_hash_table(writer, Z_ARRVAL_P(trace), level + 1) != 1) {
+                return 0;
+            }
+            break;
+        case IS_DOUBLE:
+            json_writer_double(writer, Z_DVAL_P(trace));
+            break;
+        case IS_LONG:
+            json_writer_i64(writer, Z_LVAL_P(trace));
+            break;
+        case IS_NULL:
+            json_writer_null(writer);
+            break;
+        case IS_TRUE:
+        case IS_FALSE:
+            json_writer_bool(writer, Z_TYPE_P(trace) == IS_TRUE);
+            break;
+        case IS_STRING:
+            json_writer_utf8(writer, Z_STRVAL_P(trace));
+            break;
+        default:
+            ddtrace_log_debug("Serialize values must be of type array, string, int, float, bool or null");
+            return 0;
+            break;
+    }
+    return 1;
+}
+
+// SIGNALFX: JSON equivalent for ddtrace_serialize_simple_array_into_c_string
+int ddtrace_serialize_simple_array_into_c_string_json(zval *trace, char **data_p, size_t *size_p) {
+    // encode to memory buffer
+    char *data;
+    size_t size;
+    json_writer_s writer;
+    json_writer_initialize(&writer);
+    if (json_write_zval(&writer, trace, 0) != 1) {
+        json_writer_destroy(&writer);
+        return 0;
+    }
+
+    bool written = json_writer_complete(&writer, &data, &size);
+    json_writer_destroy(&writer);
+
+    if (!written) {
         return 0;
     }
 

--- a/ext/php7/serializer.h
+++ b/ext/php7/serializer.h
@@ -4,6 +4,8 @@
 
 int ddtrace_serialize_simple_array(zval *trace, zval *retval);
 int ddtrace_serialize_simple_array_into_c_string(zval *trace, char **data_p, size_t *size_p);
+// SIGNALFX: custom JSON serializer, see implementation
+int ddtrace_serialize_simple_array_into_c_string_json(zval *trace, char **data_p, size_t *size_p);
 
 void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array);
 

--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -183,6 +183,7 @@ static size_t _dd_curl_write_noop(void *ptr, size_t size, size_t nmemb, void *us
 }
 
 static size_t _dd_check_for_agent_error(char *error, bool quick) {
+    // SIGNALFX: do not perform a diagnostic check for endpoint on startup
     if (get_global_SIGNALFX_MODE()) {
         error[0] = 0;
         return 0;

--- a/ext/php8/comms_php.c
+++ b/ext/php8/comms_php.c
@@ -48,3 +48,24 @@ bool ddtrace_send_traces_via_thread(size_t num_traces, char *payload, size_t pay
     mpack_reader_destroy(&reader);
     return sent_to_background_sender;
 }
+
+// SIGNALFX: similar to ddtrace_send_traces_via_thread, but takes one trace instead of an array,
+// as that depends on the payload being msgpack, whereas this method is agnostic to serialization,
+// allowing JSON
+bool ddtrace_send_trace_via_thread(char *payload, size_t payload_len) {
+    if (!get_DD_TRACE_ENABLED()) {
+        // If the tracer is set to drop all the spans, we do not signal an error.
+        ddtrace_log_debugf("Traces are dropped by PID %ld because tracing is disabled.", getpid());
+        return true;
+    }
+
+    bool sent_to_background_sender = false;
+
+    if (ddtrace_coms_buffer_data(DDTRACE_G(traces_group_id), payload, payload_len)) {
+        sent_to_background_sender = true;
+    } else {
+        ddtrace_log_debug("Unable to send payload to background sender's buffer");
+    }
+
+    return sent_to_background_sender;
+}

--- a/ext/php8/comms_php.h
+++ b/ext/php8/comms_php.h
@@ -10,5 +10,7 @@
 static const size_t AGENT_REQUEST_BODY_LIMIT = 10485760;
 
 bool ddtrace_send_traces_via_thread(size_t num_traces, char *payload, size_t payload_len);
+// SIGNALFX: single trace sender, see implementation
+bool ddtrace_send_trace_via_thread(char *payload, size_t payload_len);
 
 #endif  // DDTRACE_COMMS_PHP_H

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -470,9 +470,12 @@ static size_t _dd_coms_read_callback(char *buffer, size_t size, size_t nitems, v
     size_t written = 0;
     size_t buffer_size = size * nitems;
 
-    if (read->total_groups > 0) {
-        written += _dd_write_array_header(buffer, buffer_size, written, read->total_groups);
-        read->total_groups = 0;
+    // SIGNALFX: using JSON payload, so the msgpack array header is not required
+    if (!get_global_SIGNALFX_MODE()) {
+        if (read->total_groups > 0) {
+            written += _dd_write_array_header(buffer, buffer_size, written, read->total_groups);
+            read->total_groups = 0;
+        }
     }
 
     // write the remainder from previous iteration
@@ -561,6 +564,12 @@ static void _dd_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _g
     dest->total_groups++;
     size_t current_src_beginning = 0, next_src_beginning = 0, group_dest_beginning_position = 0;
 
+    // SIGNALFX: using JSON instead of msgpack, therefore the separate arrays in each entry need to be
+    // concatenated - these variables track the state for doing that
+    bool flattened_json = get_global_SIGNALFX_MODE();
+    size_t entries_copied = 0;
+    size_t last_entry_comma_position = 0;
+
     size_t bytes_written = atomic_load(&stack->bytes_written);
 
     while (current_src_beginning < bytes_written) {
@@ -586,6 +595,17 @@ static void _dd_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _g
                     elements_in_group++;
                     group_dest_position += copied;
                     bytes_in_group += copied;
+
+                    // SIGNALFX: concatenate JSON arrays by replacing the end ] with comma, and the begin [
+                    // with a space for entries beyond first one
+                    if (flattened_json) {
+                        dest->dest_data[group_dest_position - 1] = ',';
+                        last_entry_comma_position = group_dest_position - 1;
+                        if (entries_copied > 0) {
+                            dest->dest_data[group_dest_position - copied] = ' ';
+                        }
+                        entries_copied++;
+                    }
                 }
             } else if (next_group_entry.group_id == current_group_id && entry.group_id != GROUP_ID_PROCESSED) {
                 dest->total_groups++;  // add unique group count
@@ -605,6 +625,12 @@ static void _dd_msgpack_group_stack_by_id(ddtrace_coms_stack_t *stack, struct _g
 
         current_group_id = next_group_entry.group_id;
         current_src_beginning = next_src_beginning;
+    }
+    // SIGNALFX: replace the last comma with ] to end the JSON array properly
+    if (flattened_json) {
+        if (last_entry_comma_position > 0) {
+            dest->dest_data[last_entry_comma_position] = ']';
+        }
     }
     dest->total_bytes = group_dest_beginning_position;  // save total bytes count after conversion
 }
@@ -666,6 +692,7 @@ static void dd_append_header(struct curl_slist **list, const char *key, const ch
 static struct curl_slist *dd_agent_headers_alloc(void) {
     struct curl_slist *list = NULL;
 
+    // SIGNALFX: add access token header and skip DD specific headers
     if (get_global_SIGNALFX_MODE()) {
         zend_string *access_token = get_global_SIGNALFX_ACCESS_TOKEN();
         if (ZSTR_LEN(access_token) > 0) {
@@ -715,6 +742,7 @@ void ddtrace_curl_set_connect_timeout(CURL *curl) {
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, timeout);
 }
 
+// SIGNALFX: endpoint configuration for SignalFX uses different configuration options and includes path part
 char *signalfx_agent_url(void) {
     zend_string *url = get_global_SIGNALFX_ENDPOINT_URL();
     if (ZSTR_LEN(url) > 0) {
@@ -732,6 +760,7 @@ char *signalfx_agent_url(void) {
 }
 
 char *ddtrace_agent_url(void) {
+    // SIGNALFX: use SignalFX specific configuration options for endpoint URL
     if (get_global_SIGNALFX_MODE()) {
         return signalfx_agent_url();
     }
@@ -771,6 +800,7 @@ char *ddtrace_agent_url(void) {
 
 void ddtrace_curl_set_hostname(CURL *curl) {
     char *url = ddtrace_agent_url();
+    // SIGNALFX: SignalFX url already contains the path part, skip adding that
     if (get_global_SIGNALFX_MODE()) {
         curl_easy_setopt(curl, CURLOPT_URL, url);
     } else if (url && url[0]) {
@@ -827,11 +857,14 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
         headers = curl_slist_append(headers, current->data);
     }
     headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
-    headers = curl_slist_append(headers, "Content-Type: application/msgpack");
 
+    // SIGNALFX: sending JSON data, so set the content type to JSON instead of msgpack and skip DD specific headers
     if (get_global_SIGNALFX_MODE()) {
+        headers = curl_slist_append(headers, "Content-Type: application/json");
         goto skip_dd_headers;
     }
+
+    headers = curl_slist_append(headers, "Content-Type: application/msgpack");
 
     char buffer[64];
     int bytes_written = snprintf(buffer, sizeof buffer, DD_TRACE_COUNT_HEADER "%zu", trace_count);
@@ -863,6 +896,8 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
         ddtrace_curl_set_connect_timeout(writer->curl);
 
         curl_easy_setopt(writer->curl, CURLOPT_UPLOAD, 1);
+        // SIGNALFX: use POST instead of PUT for the upload
+        curl_easy_setopt(writer->curl, CURLOPT_PUT, 0);
         curl_easy_setopt(writer->curl, CURLOPT_POST, 1);
         curl_easy_setopt(writer->curl, CURLOPT_VERBOSE, get_global_DD_TRACE_AGENT_DEBUG_VERBOSE_CURL());
 

--- a/ext/php8/configuration.c
+++ b/ext/php8/configuration.c
@@ -92,6 +92,7 @@ static void dd_ini_env_to_ini_name(const zai_string_view env_name, zai_config_na
             ini_name->ptr[sizeof("datadog.trace") - 1] = '.';
         }
     } else if (env_name.ptr == strstr(env_name.ptr, "SIGNALFX_")) {
+        // SIGNALFX: allow SIGNALFX_ prefix for configuration options
         dd_copy_tolower(ini_name->ptr, env_name.ptr);
         ini_name->ptr[sizeof("signalfx") - 1] = '.';
         ini_name->len = env_name.len;

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -59,6 +59,7 @@ extern bool runtime_config_first_init;
 #define DD_CONFIGURATION                                                                                       \
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
+    /* SIGNALFX: add SignalFX specific configuration options */                                                \
     CONFIG(BOOL, SIGNALFX_MODE, "false")                                                                       \
     CONFIG(STRING, SIGNALFX_ENDPOINT_URL, "")                                                                  \
     CONFIG(STRING, SIGNALFX_ENDPOINT_HOST, "localhost")                                                        \

--- a/ext/php8/serializer.h
+++ b/ext/php8/serializer.h
@@ -4,6 +4,8 @@
 
 int ddtrace_serialize_simple_array(zval *trace, zval *retval);
 int ddtrace_serialize_simple_array_into_c_string(zval *trace, char **data_p, size_t *size_p);
+// SIGNALFX: custom JSON serializer, see implementation
+int ddtrace_serialize_simple_array_into_c_string_json(zval *trace, char **data_p, size_t *size_p);
 
 void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array);
 

--- a/ext/php8/startup_logging.c
+++ b/ext/php8/startup_logging.c
@@ -183,6 +183,7 @@ static size_t _dd_curl_write_noop(void *ptr, size_t size, size_t nmemb, void *us
 }
 
 static size_t _dd_check_for_agent_error(char *error, bool quick) {
+    // SIGNALFX: do not perform a diagnostic check for endpoint on startup
     if (get_global_SIGNALFX_MODE()) {
         error[0] = 0;
         return 0;

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -69,6 +69,8 @@ static void zai_config_copy_name(zai_config_name *dest, zai_string_view src) {
     dest->len = src.len;
 }
 
+// SIGNALFX: functions for adding SIGNALFX_ prefixed aliases and custom aliases for an upstream DD_
+// configuration option.
 static void signalfx_memoize_alternate_name(zai_config_memoized_entry *memoized, zai_string_view *name,
                                             zai_string_view dd_name, zai_string_view sfx_name) {
     if (memoized->names_count >= ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX) {
@@ -124,6 +126,8 @@ static zai_config_memoized_entry *zai_config_memoize_entry(zai_config_entry *ent
            "Number of aliases + name are greater than ZAI_CONFIG_NAMES_COUNT_MAX");
 
     zai_config_memoized_entry *memoized = &zai_config_memoized_entries[entry->id];
+    // SIGNALFX: add SIGNALFX_ prefixed aliases for a configuration option, which have a higher priority
+    // than the DD_ aliases
     signalfx_memoize_entry_alternate_names(memoized, entry);
 
     uint8_t names_start_index = memoized->names_count;

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -19,6 +19,8 @@ typedef uint16_t zai_config_id;
 
 #define ZAI_CONFIG_ENTRIES_COUNT_MAX 160
 #define ZAI_CONFIG_NAMES_COUNT_MAX 4
+// SIGNALFX: increase internal size of names array to 2x+1 of original to accomodate SIGNALFX_ prefixed
+// variations and a possible fully custom name
 #define ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX (ZAI_CONFIG_NAMES_COUNT_MAX + 1)
 #define ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX (ZAI_CONFIG_NAMES_COUNT_MAX + ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX)
 #define ZAI_CONFIG_NAME_BUFSIZ 60
@@ -54,6 +56,7 @@ struct zai_config_name_s {
 };
 
 struct zai_config_memoized_entry_s {
+    // SIGNALFX: use internal names maximum for array size instead of the maximum for explicitly defined name count
     zai_config_name names[ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX];
     zend_ini_entry *ini_entries[ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX];
     uint8_t names_count;

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -234,6 +234,7 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
 }
 
 // PHP 5 expects 'static storage duration for ini entry names
+// SIGNALFX: use internal names maximum for array size instead of the maximum for explicitly defined name count
 zai_config_name ini_names[ZAI_CONFIG_ENTRIES_COUNT_MAX * ZAI_CONFIG_NAMES_COUNT_INTERNAL_MAX];
 
 void zai_config_ini_minit(zai_config_env_to_ini_name env_to_ini, int module_number) {

--- a/zend_abstract_interface/signalfx/json_writer.c
+++ b/zend_abstract_interface/signalfx/json_writer.c
@@ -1,0 +1,341 @@
+#include "json_writer.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <string.h>
+
+// SIGNALFX: JSON writer for SignalFX zipkin sender, placed in ZAI avoid copying between PHP7 and PHP8
+#define MAX_UINT64_STRING_LENGTH 20
+#define INITIAL_ALLOC_SIZE 128
+#define MINIMUM_RESERVE_ON_ALLOC 32
+
+static bool json_writer_guarantee_remaining(json_writer_s *writer, size_t required_remaining) {
+    size_t required_size = writer->position + required_remaining + 1;
+
+    if (writer->size >= required_size) {
+        return true;
+    }
+
+    size_t doubled_size = writer->size > 0 ? writer->size * 2 : INITIAL_ALLOC_SIZE;
+    size_t minimum_size = required_size + MINIMUM_RESERVE_ON_ALLOC;
+
+    size_t new_size = minimum_size > doubled_size ? minimum_size : doubled_size;
+
+    char *new_buffer = malloc(new_size);
+
+    if (new_buffer == NULL) {
+        writer->error = json_writer_error_oom;
+        return false;
+    }
+
+    memcpy(new_buffer, writer->buffer, writer->position);
+    free(writer->buffer);
+
+    writer->buffer = new_buffer;
+    writer->size = new_size;
+    return true;
+}
+
+static bool json_writer_has_error(json_writer_s *writer) {
+    return writer->error != json_writer_error_ok;
+}
+
+void json_writer_initialize(json_writer_s *writer) {
+    writer->buffer = NULL;
+    writer->error = json_writer_error_ok;
+    writer->position = 0;
+    writer->size = 0;
+}
+
+void json_writer_destroy(json_writer_s *writer) {
+    if (writer->buffer != NULL) {
+        free(writer->buffer);
+    }
+}
+
+bool json_writer_complete(json_writer_s *writer, char **buffer, size_t *size) {
+    if (json_writer_has_error(writer)) {
+        return false;
+    } else if (!json_writer_guarantee_remaining(writer, 0)) {
+        return false;
+    }
+
+    writer->buffer[writer->position] = '\0';
+
+    *buffer = writer->buffer;
+    *size = writer->position;
+
+    writer->buffer = NULL;
+    writer->size = 0;
+    writer->position = 0;
+
+    return true;
+}
+
+const char *json_writer_error_as_string(json_writer_s *writer) {
+    switch (writer->error) {
+    case json_writer_error_oom:
+        return "error_oom";
+    case json_writer_error_utf8:
+        return "error_utf8";
+    case json_writer_error_printf:
+        return "error_printf";
+    default:
+        return "ok";
+    }
+}
+
+static void json_writer_append_raw_char(json_writer_s *writer, char character) {
+    if (!json_writer_guarantee_remaining(writer, 1)) {
+        return;
+    }
+
+    writer->buffer[writer->position++] = character;
+}
+
+static void json_writer_append_raw_string(json_writer_s *writer, const char *string, size_t length) {
+    if (!json_writer_guarantee_remaining(writer, length)) {
+        return;
+    }
+
+    memcpy(&writer->buffer[writer->position], string, length);
+    writer->position += length;
+}
+
+void json_writer_array_begin(json_writer_s *writer) {
+    json_writer_append_raw_char(writer, '[');
+}
+
+void json_writer_array_end(json_writer_s *writer) {
+    json_writer_append_raw_char(writer, ']');
+}
+
+void json_writer_object_begin(json_writer_s *writer) {
+    json_writer_append_raw_char(writer, '{');
+}
+
+void json_writer_object_end(json_writer_s *writer) {
+    json_writer_append_raw_char(writer, '}');
+}
+
+void json_writer_element_separator(json_writer_s *writer) {
+    json_writer_append_raw_char(writer, ',');
+}
+
+void json_writer_key_value_separator(json_writer_s *writer) {
+    json_writer_append_raw_char(writer, ':');
+}
+
+static bool json_writer_check_printf_result(json_writer_s *writer, int print_result) {
+    if (print_result < 0) {
+        if (writer->error == json_writer_error_ok) {
+            writer->error = json_writer_error_printf;   
+        }
+        return false;
+    }
+    return true;
+}
+
+void json_writer_double(json_writer_s *writer, double value) {
+    int print_result = snprintf(NULL, 0, "%f", value);
+    if (!json_writer_check_printf_result(writer, print_result)) {
+        return;
+    }
+
+    size_t length = (size_t) print_result;
+
+    if (!json_writer_guarantee_remaining(writer, length)) {
+        return;
+    }
+
+    snprintf(&writer->buffer[writer->position], writer->size - writer->position + 1, "%f", value);
+    writer->position += length;
+}
+
+void json_writer_i64(json_writer_s *writer, int64_t value) {
+    if (!json_writer_guarantee_remaining(writer, MAX_UINT64_STRING_LENGTH)) {
+        return;
+    }
+
+    int print_result = snprintf(&writer->buffer[writer->position], writer->size - writer->position + 1, "%" PRId64, value);
+    if (!json_writer_check_printf_result(writer, print_result)) {
+        return;
+    }
+
+    writer->position += (size_t) print_result;
+}
+
+void json_writer_null(json_writer_s *writer) {
+    if (json_writer_has_error(writer)) {
+        return;
+    }
+
+    json_writer_append_raw_string(writer, "null", 4);
+}
+
+void json_writer_bool(json_writer_s *writer, bool value) {
+    if (json_writer_has_error(writer)) {
+        return;
+    } else if (value) {
+        json_writer_append_raw_string(writer, "true", 4);
+    } else {
+        json_writer_append_raw_string(writer, "false", 5);
+    }
+}
+
+typedef enum utf8_advance_result_e {
+    utf8_advance_null = 0,
+    utf8_advance_escape_control = 1,
+    utf8_advance_escape_special = 2,
+    utf8_advance_error = 3
+} utf8_advance_result_e;
+
+static bool utf8_is_continuation_byte(uint8_t byte) {
+    return (byte & 0xC0) == 0x80;
+}
+
+static uint32_t utf8_point(uint8_t byte, int mask, uint32_t shift) {
+    return (uint32_t) (byte & (uint8_t) mask) << shift;
+}
+
+static utf8_advance_result_e utf8_advance(const uint8_t *buffer, size_t *chunk_length) {
+    const uint8_t *cursor = buffer;
+
+    while (true) {
+        uint8_t byte0 = cursor[0];
+
+        if (byte0 < 0x80) {
+            if (byte0 < 0x20) {
+                *chunk_length = cursor - buffer;
+                if (byte0 == '\0') {
+                    return utf8_advance_null;
+                } else {
+                    return utf8_advance_escape_control;
+                }
+            } else if (byte0 == '\"' || byte0 == '\\') {
+                *chunk_length = cursor - buffer;
+                return utf8_advance_escape_special;
+            }
+
+            cursor += 1;
+        } else if ((byte0 & 0xE0) == 0xC0) {
+            uint8_t byte1 = cursor[1];
+            if (!utf8_is_continuation_byte(byte1)) {
+                return utf8_advance_error;
+            }
+
+            uint32_t codepoint = utf8_point(byte0, ~0xE0, 6) | utf8_point(byte1, ~0xC0, 0);
+
+            if (codepoint < 0x80) {
+                return utf8_advance_error;
+            }
+
+            cursor += 2;
+        } else if ((byte0 & 0xF0) == 0xE0) {
+            uint8_t byte1 = cursor[1];
+            if (!utf8_is_continuation_byte(byte1)) {
+                return utf8_advance_error;
+            }
+            uint8_t byte2 = cursor[2];
+            if (!utf8_is_continuation_byte(byte2)) {
+                return utf8_advance_error;
+            }
+
+            uint32_t codepoint = utf8_point(byte0, ~0xF0, 12) | 
+                utf8_point(byte1, ~0xC0, 6) | utf8_point(byte2, ~0xC0, 0);
+
+            if (codepoint < 0x80) {
+                return utf8_advance_error;
+            } else if (codepoint >= 0xD800 && codepoint <= 0xDFFF) {
+                return utf8_advance_error;
+            }
+
+            cursor += 3;
+        } else if ((byte0 & 0xF8) == 0xF0) {
+            uint8_t byte1 = cursor[1];
+            if (!utf8_is_continuation_byte(byte1)) {
+                return utf8_advance_error;
+            }
+            uint8_t byte2 = cursor[2];
+            if (!utf8_is_continuation_byte(byte2)) {
+                return utf8_advance_error;
+            }
+            uint8_t byte3 = cursor[3];
+            if (!utf8_is_continuation_byte(byte3)) {
+                return utf8_advance_error;
+            }
+
+            uint32_t codepoint = utf8_point(byte0, ~0xF8, 18) | utf8_point(byte1, ~0xC0, 12) | 
+                utf8_point(byte2, ~0xC0, 6) | utf8_point(byte3, ~0xC0, 0);
+
+            if (codepoint < 0x10000 || codepoint >= 0x10FFFF) {
+                return utf8_advance_error;
+            }
+            
+            cursor += 4;
+        } else {
+            return utf8_advance_error;
+        }
+    }
+}
+
+static char hex_digit(uint8_t number) {
+    if (number < 10) {
+        return '0' + number;
+    } else {
+        return 'A' + number - 10;
+    }
+}
+
+void json_writer_utf8(json_writer_s *writer, const char *utf8_string) {
+    json_writer_append_raw_char(writer, '\"');
+
+    size_t position = 0;
+
+    while (true) {
+        size_t chunk_length;
+        const char *chunk = &utf8_string[position];
+
+        utf8_advance_result_e result = utf8_advance((const uint8_t *) chunk, &chunk_length);
+
+        if (result == utf8_advance_error) {
+            return;
+        }
+
+        if (chunk_length > 0) {
+            json_writer_append_raw_string(writer, chunk, chunk_length);
+
+            if (json_writer_has_error(writer)) {
+                return;
+            }
+        }
+
+        if (result == utf8_advance_null) {
+            break;
+        } else if (result == utf8_advance_escape_control) {
+            if (!json_writer_guarantee_remaining(writer, 6)) {
+                return;
+            }
+
+            char control_character = chunk[chunk_length];
+            writer->buffer[writer->position++] = '\\';
+            writer->buffer[writer->position++] = 'u';
+            writer->buffer[writer->position++] = '0';
+            writer->buffer[writer->position++] = '0';
+            writer->buffer[writer->position++] = hex_digit(((uint8_t) control_character) >> 4);
+            writer->buffer[writer->position++] = hex_digit(((uint8_t) control_character) & 0x0F);
+        } else {
+            if (!json_writer_guarantee_remaining(writer, 2)) {
+                return;
+            }
+
+            writer->buffer[writer->position++] = '\\';
+            writer->buffer[writer->position++] = chunk[chunk_length];
+        }
+
+        position += chunk_length + 1;
+    }
+
+    json_writer_append_raw_char(writer, '\"');
+}

--- a/zend_abstract_interface/signalfx/json_writer.h
+++ b/zend_abstract_interface/signalfx/json_writer.h
@@ -1,0 +1,44 @@
+#ifndef ZAI_SIGNALFX_JSON_WRITER_H
+#define ZAI_SIGNALFX_JSON_WRITER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+// SIGNALFX: JSON writer for SignalFX zipkin sender, placed in ZAI avoid copying between PHP7 and PHP8
+typedef enum json_writer_error_e {
+    json_writer_error_ok = 0,
+    json_writer_error_oom = 1,
+    json_writer_error_utf8 = 2,
+    json_writer_error_printf = 3
+} json_writer_error_e;
+
+typedef struct json_writer_s {
+    char* buffer;
+    size_t position;
+    size_t size;
+    json_writer_error_e error;
+} json_writer_s;
+
+void json_writer_initialize(json_writer_s *writer);
+void json_writer_destroy(json_writer_s *writer);
+bool json_writer_complete(json_writer_s *writer, char **buffer, size_t *size);
+
+const char* json_writer_error_as_string(json_writer_s *writer);
+
+void json_writer_array_begin(json_writer_s *writer);
+void json_writer_array_end(json_writer_s *writer);
+
+void json_writer_object_begin(json_writer_s *writer);
+void json_writer_object_end(json_writer_s *writer);
+
+void json_writer_element_separator(json_writer_s *writer);
+void json_writer_key_value_separator(json_writer_s *writer);
+
+void json_writer_double(json_writer_s *writer, double value);
+void json_writer_i64(json_writer_s *writer, int64_t value);
+void json_writer_null(json_writer_s *writer);
+void json_writer_bool(json_writer_s *writer, bool value);
+void json_writer_utf8(json_writer_s *writer, const char *utf8_string);
+
+#endif


### PR DESCRIPTION
This PR makes the exporter serialize and send the payload as JSON instead of msgpack if SignalFX mode is enabled. This removes one level of nesting from the data as for Zipkin format there is no concept of span groups.

Since msgpack allowed to just append different payloads together in the exporter with no changes to their content, some manipulation of the payloads was necessary while building the combined JSON payload - first and last characters of payloads are modified to "concatenate" the arrays in the payloads (ending `]` is changed to `,`, starting `[` is changed to whitespace, last character of combined payload is changed back to `]`).

The JSON serializer is implemented from scratch because the use case needed here is extremely minimal, and this approach allowed to have no intermediate representation of the data between the PHP-specific objects and the serialized bytes. The serializer files are added to the ZAI (zend abstract interface) subproject as this allows to not duplicate them for php7 and php8 extension subprojects.

Additionally, added comments starting with `// SIGNALFX:` to all current changes and changes from previous PR. This allows to easily find every single customization that has been done to this codebase and explain its purpose.