### PR TITLE
 Refork - span JSON converted to Zipkin format, B3 propagation, SFX specific config defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2622,10 +2622,7 @@ workflows:
             parameters:
               php_version:
                 - '8.0'
-
-      - system_tests:
-          requires: [ 'package extension' ]
-          name: "System tests"
+      # SIGNALFX: System tests removed, requires DD backend
 
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: "2.1"
-orbs:
-  codecov: codecov/codecov@3.2.2
+# SIGNALFX: codecov orb removed as it has not been set up for our CI
 aliases:
 
   - &CACHE_COMPOSER_KEY
@@ -556,57 +555,7 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
-  coverage: &TEST_BASE
-    parameters:
-      php_major_minor:
-        # Expected in the format: <major>.<minor>, e.g. 8.2
-        type: string
-      make_target:
-        type: string
-      switch_php_version:
-        type: string
-        default: none
-      resource_class:
-        type: string
-        default: medium
-    working_directory: ~/datadog
-    <<: *BARE_DOCKER_MACHINE
-    steps:
-      - <<: *STEP_ATTACH_WORKSPACE
-      - setup_docker:
-          docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
-          extra: with_httpbin_and_request_replayer
-      - switch_php:
-          php_version: << parameters.switch_php_version >>
-      - <<: *STEP_EXPORT_CI_ENV
-      - <<: *STEP_WAIT_REQUEST_REPLAYER
-      - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
-      - run:
-          name: Run tests
-          command: |
-            set -euo pipefail
-            make << parameters.make_target >> 2>&1 | tee /dev/stderr | { ! grep -qe "=== Total [0-9]+ memory leaks detected ==="; }
-      - when:
-          # codecov uploader only on amd64
-          condition:
-            matches:
-              pattern: "^[^.]+$"
-              value: << parameters.resource_class >>
-          steps:
-            - run:
-                name: Install CodeCov Uploader Dependencies
-                command: sudo apt install -y gpg
-            - codecov/upload:
-                file: tmp/coverage.info
-                upload_name: "PHP<< parameters.php_major_minor >>.dd-trace-php"
-      - run:
-          command: |
-            mkdir -p /tmp/artifacts/core_dumps
-            find tmp -name "core.*" | xargs -I % -n 1 cp % /tmp/artifacts/core_dumps
-            cp -a tmp/build_extension/tests/ext /tmp/artifacts/tests
-          when: on_fail
-      - store_artifacts:
-          path: /tmp/artifacts
+  # SIGNALFX: coverage job removed because our CI does not have exporting this set up
 
   asan: *TEST_BASE
 
@@ -2696,27 +2645,14 @@ workflows:
                 - "8.0"
                 - "8.1"
               make_target:
-                - test_coverage
+                # SIGNALFX: coverage target removed
                 - test_extension_ci
                 - test_unit
                 - test_api_unit
                 - test_c2php
                 - test_c_disabled
                 - test_internal_api_randomized
-      - coverage:
-          requires: [ 'Prepare Code' ]
-          matrix:
-            parameters:
-              php_major_minor:
-                - "7.0"
-                - "7.1"
-                - "7.2"
-                - "7.3"
-                - "7.4"
-                - "8.0"
-                - "8.1"
-              make_target:
-                - test_coverage
+      # SIGNALFX: coverage job removed because our CI does not have exporting this set up
       - asan:
           requires: [ 'Prepare Code' ]
           matrix:

--- a/config.m4
+++ b/config.m4
@@ -219,6 +219,8 @@ if test "$PHP_DDTRACE" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php7])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/sandbox/php8])
+  dnl SIGNALFX: signalfx ZAI directory added
+  PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/signalfx])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/uri_normalization])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_assert])
   PHP_ADD_BUILD_DIR([$ext_builddir/zend_abstract_interface/zai_string])

--- a/config.m4
+++ b/config.m4
@@ -106,6 +106,7 @@ if test "$PHP_DDTRACE" != "no"; then
       zend_abstract_interface/interceptor/php7/interceptor.c \
       zend_abstract_interface/interceptor/php7/resolver.c \
       zend_abstract_interface/json/json.c \
+      zend_abstract_interface/signalfx/json_writer.c \
       zend_abstract_interface/symbols/lookup.c \
       zend_abstract_interface/symbols/call.c \
       zend_abstract_interface/sandbox/php7/sandbox.c \

--- a/ext/php7/coms.c
+++ b/ext/php7/coms.c
@@ -760,7 +760,7 @@ char *signalfx_agent_url(void) {
     zend_string *port = get_global_SIGNALFX_ENDPOINT_PORT();
     zend_string *path = get_global_SIGNALFX_ENDPOINT_PATH();
     char *formatted_url;
-    asprintf(&formatted_url, "%s%s:%s%s", is_https ? "https://" : "http://", ZSTR_VAL(host), ZSTR_VAL(port), 
+    asprintf(&formatted_url, "%s%s:%s%s", is_https ? "https://" : "http://", ZSTR_VAL(host), ZSTR_VAL(port),
              ZSTR_VAL(path));
     return formatted_url;
 }

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -638,6 +638,13 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     pthread_once(&dd_rinit_config_once_control, ddtrace_config_first_rinit);
     zai_config_rinit();
 
+    // SIGNALFX: change default values for some configuration options if SFX mode is enabled
+    if (get_global_SIGNALFX_MODE()) {
+        zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_PROPAGATION_STYLE_EXTRACT, ZAI_STRL_VIEW("B3,B3 single header"));
+        zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_PROPAGATION_STYLE_INJECT, ZAI_STRL_VIEW("B3"));
+        zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_SERVICE, ZAI_STRL_VIEW("unnamed-php-service"));
+    }
+
     if (ZSTR_LEN(get_DD_SPAN_SAMPLING_RULES_FILE()) > 0 && !zend_string_equals(get_global_DD_SPAN_SAMPLING_RULES_FILE(), get_DD_SPAN_SAMPLING_RULES_FILE())) {
         dd_save_sampling_rules_file_config(get_DD_SPAN_SAMPLING_RULES_FILE(), PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
     }

--- a/ext/php7/handlers_curl.c
+++ b/ext/php7/handlers_curl.c
@@ -149,7 +149,8 @@ static int dd_inject_distributed_tracing_headers(zval *ch) {
         }
     }
     zend_string *propagated_tags = ddtrace_format_propagated_tags();
-    if (propagated_tags) {
+    // SIGNALFX: do not send DD tags header if SFX mode is enabled
+    if (propagated_tags && !get_global_SIGNALFX_MODE()) {
         add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-tags: %s", ZSTR_VAL(propagated_tags)));
         zend_string_release(propagated_tags);
     }

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -1062,7 +1062,7 @@ static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span
         }
     }
 
-    // Pseudo: sfx_span['tags']['resource.name'] = dd_span['resource'] (if tag not yet present and 
+    // Pseudo: sfx_span['tags']['resource.name'] = dd_span['resource'] (if tag not yet present and
     // doesn't equal span name)
     if (zend_hash_str_find(Z_ARR_P(tags), ZEND_STRL(SFX_TAG_RESOURCE_NAME)) == NULL) {
         zval *dd_resource = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("resource"));

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -257,7 +257,7 @@ int ddtrace_serialize_simple_array_into_c_string_json(zval *trace, char **data_p
     size_t size;
     json_writer_s writer;
     json_writer_initialize(&writer);
-    if (json_write_zval(&writer, trace, 0) != 1) {
+    if (json_write_zval(&writer, trace) != 1) {
         json_writer_destroy(&writer);
         return 0;
     }

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -153,11 +153,11 @@ int ddtrace_serialize_simple_array_into_c_string(zval *trace, char **data_p, siz
     }
 }
 
-static int json_write_zval(json_writer_s *writer, zval *trace, int level);
+static int json_write_zval(json_writer_s *writer, zval *trace);
 
 // SIGNALFX: JSON equivalent for msgpack write_hash_table, additionally it does
 // not change trace/span IDs to number types as is done for msgpack
-static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level) {
+static int json_write_hash_table(json_writer_s *writer, HashTable *ht) {
     zval *tmp;
     zend_string *string_key;
     zend_long num_key;
@@ -181,7 +181,7 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level
 
     ZEND_HASH_FOREACH_KEY_VAL_IND(ht, num_key, string_key, tmp) {
         if (is_first) {
-            is_first = false;    
+            is_first = false;
         } else {
             json_writer_element_separator(writer);
         }
@@ -200,7 +200,7 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level
         }
 
         // Writing the value
-        if (json_write_zval(writer, tmp, level) != 1) {
+        if (json_write_zval(writer, tmp) != 1) {
             return 0;
         }
     }
@@ -215,14 +215,14 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level
 }
 
 // SIGNALFX: JSON equivalent for msgpack msgpack_write_zval
-static int json_write_zval(json_writer_s *writer, zval *trace, int level) {
+static int json_write_zval(json_writer_s *writer, zval *trace) {
     if (Z_TYPE_P(trace) == IS_REFERENCE) {
         trace = Z_REFVAL_P(trace);
     }
 
     switch (Z_TYPE_P(trace)) {
         case IS_ARRAY:
-            if (json_write_hash_table(writer, Z_ARRVAL_P(trace), level + 1) != 1) {
+            if (json_write_hash_table(writer, Z_ARRVAL_P(trace)) != 1) {
                 return 0;
             }
             break;
@@ -959,6 +959,158 @@ void ddtrace_shutdown_span_sampling_limiter(void) {
     zend_hash_destroy(&dd_span_sampling_limiters);
 }
 
+// SIGNALFX: Functions to convert DD serialized span array to SFX serialized span array
+#define SFX_ATTRIBUTE_KIND "kind"
+#define SFX_TAG_COMPONENT "component"
+#define SFX_TAG_RESOURCE_NAME "resource.name"
+
+static bool signalfx_is_known_client_span_type(const char* dd_span_type) {
+    return
+        strcmp(dd_span_type, "http") == 0 ||
+        strcmp(dd_span_type, "sql") == 0 ||
+        strcmp(dd_span_type, "redis") == 0 ||
+        strcmp(dd_span_type, "memcached") == 0 ||
+        strcmp(dd_span_type, "elasticsearch") == 0 ||
+        strcmp(dd_span_type, "cassandra") == 0 ||
+        strcmp(dd_span_type, "mongodb") == 0;
+}
+
+static bool signalfx_is_known_server_span_type(const char* dd_span_type) {
+    return
+        strcmp(dd_span_type, "web") == 0 ||
+        strcmp(dd_span_type, "cli") == 0;
+}
+
+static void signalfx_add_assoc_hex64(zval *span, const char* name, uint64_t value) {
+    char hex_str[MAX_ID_BUFSIZ];
+    sprintf(hex_str, "%" PRIx64, value);
+    add_assoc_string(span, name, hex_str);
+}
+
+static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span_t *span, zval *dd_span) {
+    zval sfx_span_zv;
+    zval *sfx_span = &sfx_span_zv;
+    array_init(sfx_span);
+
+    // More efficient to just read from the original span structure than from serializer array
+    signalfx_add_assoc_hex64(sfx_span, "traceId", span->trace_id);
+    signalfx_add_assoc_hex64(sfx_span, "id", span->span_id);
+
+    if (span->parent_id > 0) {
+        signalfx_add_assoc_hex64(sfx_span, "parentId", span->parent_id);
+    }
+
+    add_assoc_long(sfx_span, "timestamp", span->start / 1000);
+    add_assoc_long(sfx_span, "duration", span->duration / 1000);
+
+    // For the rest, copy values from previously built span array to avoid being too sensitive to changes to the
+    // actual logic of how the values are constructed from span structure.
+    zval *dd_name = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("name"));
+    const char* name_cstr = NULL;
+
+    if (dd_name != NULL && Z_TYPE_P(dd_name) == IS_STRING) {
+        add_assoc_zval(sfx_span, "name", dd_name);
+        name_cstr = Z_STRVAL_P(dd_name);
+    }
+
+    zval tags_zv;
+    zval *tags = &tags_zv;
+    array_init(tags);
+
+    bool error_kind_present = false;
+    zval *dd_tags = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("meta"));
+
+    if (dd_tags != NULL && Z_TYPE_P(dd_tags) == IS_ARRAY) {
+        zend_string *str_key;
+        zval *val;
+
+        ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR_P(dd_tags), str_key, val) {
+            if (str_key != NULL) {
+                const char* cstr_key = ZSTR_VAL(str_key);
+
+                // Rename error tags
+                if (strcmp(cstr_key, "error.type") == 0) {
+                    cstr_key = "sfx.error.kind";
+                    error_kind_present = true;
+                } else if (strcmp(cstr_key, "error.msg") == 0) {
+                    cstr_key = "sfx.error.message";
+                } else if (strcmp(cstr_key, "error.stack") == 0) {
+                    cstr_key = "sfx.error.stack";
+                }
+
+                // Drop DD internal tags
+                if (strncmp(cstr_key, "_dd.", 4) == 0) {
+                    continue;
+                }
+
+                add_assoc_zval(tags, cstr_key, val);
+            }
+        }
+        ZEND_HASH_FOREACH_END();
+    }
+
+    if (error_kind_present) {
+        add_assoc_bool(tags, "error", true);
+    }
+
+    // Pseudo: sfx_span['tags']['component'] = dd_span['service'] (if tag not yet present)
+    if (zend_hash_str_find(Z_ARR_P(tags), ZEND_STRL(SFX_TAG_COMPONENT)) == NULL) {
+        zval *dd_service = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("service"));
+
+        if (dd_service != NULL && Z_TYPE_P(dd_service) == IS_STRING) {
+            add_assoc_zval(tags, SFX_TAG_COMPONENT, dd_service);
+        }
+    }
+
+    // Pseudo: sfx_span['tags']['resource.name'] = dd_span['resource'] (if tag not yet present and 
+    // doesn't equal span name)
+    if (zend_hash_str_find(Z_ARR_P(tags), ZEND_STRL(SFX_TAG_RESOURCE_NAME)) == NULL) {
+        zval *dd_resource = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("resource"));
+
+        if (dd_resource != NULL && Z_TYPE_P(dd_resource) == IS_STRING) {
+            if (name_cstr == NULL || strcmp(name_cstr, Z_STRVAL_P(dd_resource)) != 0) {
+                add_assoc_zval(tags, SFX_TAG_RESOURCE_NAME, dd_resource);
+            }
+        }
+    }
+
+    add_assoc_zval(sfx_span, "tags", tags);
+
+    // Determine if span is CLIENT or SERVER and set 'kind' and/or 'remoteEndpoint' based on that
+    zval *dd_type = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("type"));
+
+    if (dd_type != NULL && Z_TYPE_P(dd_type) == IS_STRING) {
+        if (signalfx_is_known_client_span_type(Z_STRVAL_P(dd_type))) {
+            add_assoc_string(sfx_span, SFX_ATTRIBUTE_KIND, "CLIENT");
+
+            zval *prop_service = ddtrace_spandata_property_service(span);
+
+            // Add span['remoteEndpoint']['serviceName']
+            if (prop_service != NULL) {
+                zval remote_endpoint_zv;
+                zval *remote_endpoint = &remote_endpoint_zv;
+                array_init(remote_endpoint);
+
+                add_assoc_zval(remote_endpoint, "serviceName", prop_service);
+                add_assoc_zval(sfx_span, "remoteEndpoint", remote_endpoint);
+            }
+        } else if (signalfx_is_known_server_span_type(Z_STRVAL_P(dd_type))) {
+            add_assoc_string(sfx_span, SFX_ATTRIBUTE_KIND, "SERVER");
+        }
+    }
+
+    // Add span['localEndpoint']['serviceName'] with user-defined service
+    zval local_endpoint_zv;
+    zval *local_endpoint = &local_endpoint_zv;
+    array_init(local_endpoint);
+
+    add_assoc_string(local_endpoint, "serviceName", ZSTR_VAL(get_DD_SERVICE()));
+    add_assoc_zval(sfx_span, "localEndpoint", local_endpoint);
+
+    // Add SFX span array to the non-assoc array of spans
+    add_next_index_zval(spans_array, sfx_span);
+}
+
 void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
     ddtrace_span_t *span = &span_fci->span;
     bool top_level_span = span->parent_id == DDTRACE_G(distributed_parent_trace_id);
@@ -1178,6 +1330,15 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
             metrics = zend_hash_str_add_new(Z_ARR_P(el), "metrics", sizeof("metrics") - 1, &metrics_array);
         }
         add_assoc_double(metrics, "php.compilation.total_time_ms", ddtrace_compile_time_get() / 1000.);
+    }
+
+    // SIGNALFX: SFX zipkin format is different enough that it makes sense to create a new array for that and copy
+    // over what we can. Changing the above code to do it our way in the first place would be more efficient, but
+    // would likely cause conflicts in some future syncs where this approach would not.
+    if (get_global_SIGNALFX_MODE()) {
+        signalfx_serialize_sfx_span_to_array(array, span, el);
+        zval_ptr_dtor(el);
+        return;
     }
 
     add_next_index_zval(array, el);

--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -290,6 +290,10 @@ void ddtrace_startup_diagnostics(HashTable *ht, bool quick) {
         zai_config_memoized_entry *cfg = &zai_config_memoized_entries[i];
         if (cfg->name_index > 0) {
             zai_config_name *old_name = &cfg->names[cfg->name_index];
+            // SIGNALFX: Do not give the warning for the primary DD_ prefixed name
+            if (strncmp(old_name->ptr, "DD_", 3) == 0 && strncmp(cfg->names[cfg->name_index - 1].ptr, "SIGNALFX_", 9) == 0) {
+                continue;
+            }
             zend_string *message = zend_strpprintf(0, "'%s=%s' is deprecated, use %s instead.", old_name->ptr,
                                                    ZSTR_VAL(cfg->ini_entries[0]->value), cfg->names[0].ptr);
             _dd_add_assoc_zstring(ht, old_name->ptr, old_name->len, message);

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -754,7 +754,7 @@ char *signalfx_agent_url(void) {
     zend_string *port = get_global_SIGNALFX_ENDPOINT_PORT();
     zend_string *path = get_global_SIGNALFX_ENDPOINT_PATH();
     char *formatted_url;
-    asprintf(&formatted_url, "%s%s:%s%s", is_https ? "https://" : "http://", ZSTR_VAL(host), ZSTR_VAL(port), 
+    asprintf(&formatted_url, "%s%s:%s%s", is_https ? "https://" : "http://", ZSTR_VAL(host), ZSTR_VAL(port),
              ZSTR_VAL(path));
     return formatted_url;
 }

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -611,6 +611,13 @@ static PHP_RINIT_FUNCTION(ddtrace) {
     pthread_once(&dd_rinit_config_once_control, ddtrace_config_first_rinit);
     zai_config_rinit();
 
+    // SIGNALFX: change default values for some configuration options if SFX mode is enabled
+    if (get_global_SIGNALFX_MODE()) {
+        zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_PROPAGATION_STYLE_EXTRACT, ZAI_STRL_VIEW("B3,B3 single header"));
+        zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_PROPAGATION_STYLE_INJECT, ZAI_STRL_VIEW("B3"));
+        zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_SERVICE, ZAI_STRL_VIEW("unnamed-php-service"));
+    }
+
     if (ZSTR_LEN(get_DD_SPAN_SAMPLING_RULES_FILE()) > 0 && !zend_string_equals(get_global_DD_SPAN_SAMPLING_RULES_FILE(), get_DD_SPAN_SAMPLING_RULES_FILE())) {
         dd_save_sampling_rules_file_config(get_DD_SPAN_SAMPLING_RULES_FILE(), PHP_INI_USER, PHP_INI_STAGE_RUNTIME);
     }

--- a/ext/php8/handlers_curl.c
+++ b/ext/php8/handlers_curl.c
@@ -99,7 +99,8 @@ static void dd_inject_distributed_tracing_headers(zend_object *ch) {
         }
     }
     zend_string *propagated_tags = ddtrace_format_propagated_tags();
-    if (propagated_tags) {
+    // SIGNALFX: do not send DD tags header if SFX mode is enabled
+    if (propagated_tags && !get_global_SIGNALFX_MODE()) {
         add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-tags: %s", ZSTR_VAL(propagated_tags)));
         zend_string_release(propagated_tags);
     }

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -157,11 +157,11 @@ int ddtrace_serialize_simple_array_into_c_string(zval *trace, char **data_p, siz
     }
 }
 
-static int json_write_zval(json_writer_s *writer, zval *trace, int level);
+static int json_write_zval(json_writer_s *writer, zval *trace);
 
 // SIGNALFX: JSON equivalent for msgpack write_hash_table, additionally it does
 // not change trace/span IDs to number types as is done for msgpack
-static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level) {
+static int json_write_hash_table(json_writer_s *writer, HashTable *ht) {
     zval *tmp;
     zend_string *string_key;
     zend_long num_key;
@@ -185,7 +185,7 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level
 
     ZEND_HASH_FOREACH_KEY_VAL_IND(ht, num_key, string_key, tmp) {
         if (is_first) {
-            is_first = false;    
+            is_first = false;
         } else {
             json_writer_element_separator(writer);
         }
@@ -204,7 +204,7 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level
         }
 
         // Writing the value
-        if (json_write_zval(writer, tmp, level) != 1) {
+        if (json_write_zval(writer, tmp) != 1) {
             return 0;
         }
     }
@@ -219,14 +219,14 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht, int level
 }
 
 // SIGNALFX: JSON equivalent for msgpack msgpack_write_zval
-static int json_write_zval(json_writer_s *writer, zval *trace, int level) {
+static int json_write_zval(json_writer_s *writer, zval *trace) {
     if (Z_TYPE_P(trace) == IS_REFERENCE) {
         trace = Z_REFVAL_P(trace);
     }
 
     switch (Z_TYPE_P(trace)) {
         case IS_ARRAY:
-            if (json_write_hash_table(writer, Z_ARRVAL_P(trace), level + 1) != 1) {
+            if (json_write_hash_table(writer, Z_ARRVAL_P(trace)) != 1) {
                 return 0;
             }
             break;
@@ -261,7 +261,7 @@ int ddtrace_serialize_simple_array_into_c_string_json(zval *trace, char **data_p
     size_t size;
     json_writer_s writer;
     json_writer_initialize(&writer);
-    if (json_write_zval(&writer, trace, 0) != 1) {
+    if (json_write_zval(&writer, trace) != 1) {
         json_writer_destroy(&writer);
         return 0;
     }
@@ -958,6 +958,158 @@ void ddtrace_shutdown_span_sampling_limiter(void) {
     zend_hash_destroy(&dd_span_sampling_limiters);
 }
 
+// SIGNALFX: Functions to convert DD serialized span array to SFX serialized span array
+#define SFX_ATTRIBUTE_KIND "kind"
+#define SFX_TAG_COMPONENT "component"
+#define SFX_TAG_RESOURCE_NAME "resource.name"
+
+static bool signalfx_is_known_client_span_type(const char* dd_span_type) {
+    return
+        strcmp(dd_span_type, "http") == 0 ||
+        strcmp(dd_span_type, "sql") == 0 ||
+        strcmp(dd_span_type, "redis") == 0 ||
+        strcmp(dd_span_type, "memcached") == 0 ||
+        strcmp(dd_span_type, "elasticsearch") == 0 ||
+        strcmp(dd_span_type, "cassandra") == 0 ||
+        strcmp(dd_span_type, "mongodb") == 0;
+}
+
+static bool signalfx_is_known_server_span_type(const char* dd_span_type) {
+    return
+        strcmp(dd_span_type, "web") == 0 ||
+        strcmp(dd_span_type, "cli") == 0;
+}
+
+static void signalfx_add_assoc_hex64(zval *span, const char* name, uint64_t value) {
+    char hex_str[MAX_ID_BUFSIZ];
+    sprintf(hex_str, "%" PRIx64, value);
+    add_assoc_string(span, name, hex_str);
+}
+
+static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span_t *span, zval *dd_span) {
+    zval sfx_span_zv;
+    zval *sfx_span = &sfx_span_zv;
+    array_init(sfx_span);
+
+    // More efficient to just read from the original span structure than from serializer array
+    signalfx_add_assoc_hex64(sfx_span, "traceId", span->trace_id);
+    signalfx_add_assoc_hex64(sfx_span, "id", span->span_id);
+
+    if (span->parent_id > 0) {
+        signalfx_add_assoc_hex64(sfx_span, "parentId", span->parent_id);
+    }
+
+    add_assoc_long(sfx_span, "timestamp", span->start / 1000);
+    add_assoc_long(sfx_span, "duration", span->duration / 1000);
+
+    // For the rest, copy values from previously built span array to avoid being too sensitive to changes to the
+    // actual logic of how the values are constructed from span structure.
+    zval *dd_name = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("name"));
+    const char* name_cstr = NULL;
+
+    if (dd_name != NULL && Z_TYPE_P(dd_name) == IS_STRING) {
+        add_assoc_zval(sfx_span, "name", dd_name);
+        name_cstr = Z_STRVAL_P(dd_name);
+    }
+
+    zval tags_zv;
+    zval *tags = &tags_zv;
+    array_init(tags);
+
+    bool error_kind_present = false;
+    zval *dd_tags = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("meta"));
+
+    if (dd_tags != NULL && Z_TYPE_P(dd_tags) == IS_ARRAY) {
+        zend_string *str_key;
+        zval *val;
+
+        ZEND_HASH_FOREACH_STR_KEY_VAL_IND(Z_ARR_P(dd_tags), str_key, val) {
+            if (str_key != NULL) {
+                const char* cstr_key = ZSTR_VAL(str_key);
+
+                // Rename error tags
+                if (strcmp(cstr_key, "error.type") == 0) {
+                    cstr_key = "sfx.error.kind";
+                    error_kind_present = true;
+                } else if (strcmp(cstr_key, "error.msg") == 0) {
+                    cstr_key = "sfx.error.message";
+                } else if (strcmp(cstr_key, "error.stack") == 0) {
+                    cstr_key = "sfx.error.stack";
+                }
+
+                // Drop DD internal tags
+                if (strncmp(cstr_key, "_dd.", 4) == 0) {
+                    continue;
+                }
+
+                add_assoc_zval(tags, cstr_key, val);
+            }
+        }
+        ZEND_HASH_FOREACH_END();
+    }
+
+    if (error_kind_present) {
+        add_assoc_bool(tags, "error", true);
+    }
+
+    // Pseudo: sfx_span['tags']['component'] = dd_span['service'] (if tag not yet present)
+    if (zend_hash_str_find(Z_ARR_P(tags), ZEND_STRL(SFX_TAG_COMPONENT)) == NULL) {
+        zval *dd_service = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("service"));
+
+        if (dd_service != NULL && Z_TYPE_P(dd_service) == IS_STRING) {
+            add_assoc_zval(tags, SFX_TAG_COMPONENT, dd_service);
+        }
+    }
+
+    // Pseudo: sfx_span['tags']['resource.name'] = dd_span['resource'] (if tag not yet present and 
+    // doesn't equal span name)
+    if (zend_hash_str_find(Z_ARR_P(tags), ZEND_STRL(SFX_TAG_RESOURCE_NAME)) == NULL) {
+        zval *dd_resource = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("resource"));
+
+        if (dd_resource != NULL && Z_TYPE_P(dd_resource) == IS_STRING) {
+            if (name_cstr == NULL || strcmp(name_cstr, Z_STRVAL_P(dd_resource)) != 0) {
+                add_assoc_zval(tags, SFX_TAG_RESOURCE_NAME, dd_resource);
+            }
+        }
+    }
+
+    add_assoc_zval(sfx_span, "tags", tags);
+
+    // Determine if span is CLIENT or SERVER and set 'kind' and/or 'remoteEndpoint' based on that
+    zval *dd_type = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("type"));
+
+    if (dd_type != NULL && Z_TYPE_P(dd_type) == IS_STRING) {
+        if (signalfx_is_known_client_span_type(Z_STRVAL_P(dd_type))) {
+            add_assoc_string(sfx_span, SFX_ATTRIBUTE_KIND, "CLIENT");
+
+            zval *prop_service = ddtrace_spandata_property_service(span);
+
+            // Add span['remoteEndpoint']['serviceName']
+            if (prop_service != NULL) {
+                zval remote_endpoint_zv;
+                zval *remote_endpoint = &remote_endpoint_zv;
+                array_init(remote_endpoint);
+
+                add_assoc_zval(remote_endpoint, "serviceName", prop_service);
+                add_assoc_zval(sfx_span, "remoteEndpoint", remote_endpoint);
+            }
+        } else if (signalfx_is_known_server_span_type(Z_STRVAL_P(dd_type))) {
+            add_assoc_string(sfx_span, SFX_ATTRIBUTE_KIND, "SERVER");
+        }
+    }
+
+    // Add span['localEndpoint']['serviceName'] with user-defined service
+    zval local_endpoint_zv;
+    zval *local_endpoint = &local_endpoint_zv;
+    array_init(local_endpoint);
+
+    add_assoc_string(local_endpoint, "serviceName", ZSTR_VAL(get_DD_SERVICE()));
+    add_assoc_zval(sfx_span, "localEndpoint", local_endpoint);
+
+    // Add SFX span array to the non-assoc array of spans
+    add_next_index_zval(spans_array, sfx_span);
+}
+
 void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
     ddtrace_span_t *span = &span_fci->span;
     bool top_level_span = span->parent_id == DDTRACE_G(distributed_parent_trace_id);
@@ -1179,6 +1331,15 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
         add_assoc_double(metrics, "php.compilation.total_time_ms", ddtrace_compile_time_get() / 1000.);
     }
 
+    // SIGNALFX: SFX zipkin format is different enough that it makes sense to create a new array for that and copy
+    // over what we can. Changing the above code to do it our way in the first place would be more efficient, but
+    // would likely cause conflicts in some future syncs where this approach would not.
+    if (get_global_SIGNALFX_MODE()) {
+        signalfx_serialize_sfx_span_to_array(array, span, el);
+        zval_ptr_dtor(el);
+        return;
+    }
+    
     add_next_index_zval(array, el);
 }
 

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -1061,7 +1061,7 @@ static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span
         }
     }
 
-    // Pseudo: sfx_span['tags']['resource.name'] = dd_span['resource'] (if tag not yet present and 
+    // Pseudo: sfx_span['tags']['resource.name'] = dd_span['resource'] (if tag not yet present and
     // doesn't equal span name)
     if (zend_hash_str_find(Z_ARR_P(tags), ZEND_STRL(SFX_TAG_RESOURCE_NAME)) == NULL) {
         zval *dd_resource = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("resource"));
@@ -1339,7 +1339,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array) {
         zval_ptr_dtor(el);
         return;
     }
-    
+
     add_next_index_zval(array, el);
 }
 

--- a/ext/php8/startup_logging.c
+++ b/ext/php8/startup_logging.c
@@ -290,6 +290,10 @@ void ddtrace_startup_diagnostics(HashTable *ht, bool quick) {
         zai_config_memoized_entry *cfg = &zai_config_memoized_entries[i];
         if (cfg->name_index > 0) {
             zai_config_name *old_name = &cfg->names[cfg->name_index];
+            // SIGNALFX: Do not give the warning for the primary DD_ prefixed name
+            if (strncmp(old_name->ptr, "DD_", 3) == 0 && strncmp(cfg->names[cfg->name_index - 1].ptr, "SIGNALFX_", 9) == 0) {
+                continue;
+            }
             zend_string *message = zend_strpprintf(0, "'%s=%s' is deprecated, use %s instead.", old_name->ptr,
                                                    ZSTR_VAL(cfg->ini_entries[0]->value), cfg->names[0].ptr);
             _dd_add_assoc_zstring(ht, old_name->ptr, old_name->len, message);

--- a/tests/ext/startup_logging_diagnostics.phpt
+++ b/tests/ext/startup_logging_diagnostics.phpt
@@ -28,7 +28,6 @@ dd_dump_startup_logs($logs, [
     'open_basedir_configured',
 ]);
 ?>
-// SIGNALFX: expected warning text changed to recommend SIGNALFX_ options instead
 --EXPECTF--
 agent_error: "%s"
 open_basedir_init_hook_allowed: false

--- a/tests/ext/startup_logging_diagnostics.phpt
+++ b/tests/ext/startup_logging_diagnostics.phpt
@@ -28,12 +28,13 @@ dd_dump_startup_logs($logs, [
     'open_basedir_configured',
 ]);
 ?>
+// SIGNALFX: expected warning text changed to recommend SIGNALFX_ options instead
 --EXPECTF--
 agent_error: "%s"
 open_basedir_init_hook_allowed: false
 open_basedir_container_tagging_allowed: false
-DD_SERVICE_NAME: "'DD_SERVICE_NAME=foo_service' is deprecated, use DD_SERVICE instead."
-DD_TRACE_GLOBAL_TAGS: "'DD_TRACE_GLOBAL_TAGS=foo:tag' is deprecated, use DD_TAGS instead."
+DD_SERVICE_NAME: "'DD_SERVICE_NAME=foo_service' is deprecated, use SIGNALFX_SERVICE instead."
+DD_TRACE_GLOBAL_TAGS: "'DD_TRACE_GLOBAL_TAGS=foo:tag' is deprecated, use SIGNALFX_TAGS instead."
 agent_url: "http://invalid_host:8126"
 d%s.request_init_hook: "%s/includes/request_init_hook.inc"
 open_basedir_configured: true

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -103,6 +103,8 @@ add_subdirectory(sandbox)
 add_subdirectory(uri_normalization)
 add_subdirectory(zai_string)
 add_subdirectory(zai_assert)
+# SIGNALFX: directory for signalfx specific ZAI source files
+add_subdirectory(signalfx)
 
 install(
   EXPORT ZendAbstractInterfaceTargets

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -208,6 +208,27 @@ void zai_config_rinit(void) {
 
 void zai_config_rshutdown(void) { zai_config_runtime_config_dtor(); }
 
+// SIGNALFX: Replace DD default value with SFX default value. This is done here rather than where
+// the configuration options are defined, as the defaults should only be set if SIGNALFX_MODE is
+// enabled, which can only be determined at runtime.
+void zai_config_use_signalfx_default(zai_config_id id, zai_string_view default_value) {
+    zai_config_memoized_entry *memoized = &zai_config_memoized_entries[id];
+
+    memoized->default_encoded_value = default_value;
+
+    // this has been manually set already, different default has no effect
+    if (memoized->name_index != -1) {
+        return;
+    }
+
+    ZVAL_UNDEF(&memoized->decoded_value);
+    if (!zai_config_decode_value(default_value, memoized->type, &memoized->decoded_value, true)) {
+        assert(0 && "Error decoding signalfx default value");
+    }
+
+    zai_config_replace_runtime_config(id, &memoized->decoded_value);
+}
+
 bool zai_config_system_ini_change(zval *old_value, zval *new_value) {
     (void)old_value;
     (void)new_value;

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -83,8 +83,8 @@ static void signalfx_memoize_alternate_name(zai_config_memoized_entry *memoized,
     zai_config_copy_name(dest, sfx_name);
 }
 
-static void signalfx_memoize_alternate_prefix(zai_config_memoized_entry *memoized, 
-                                              zai_string_view *name, zai_string_view dd_prefix, 
+static void signalfx_memoize_alternate_prefix(zai_config_memoized_entry *memoized,
+                                              zai_string_view *name, zai_string_view dd_prefix,
                                               zai_string_view sfx_prefix) {
     if (memoized->names_count >= ZAI_CONFIG_NAMES_COUNT_SIGNALFX_MAX) {
         return;
@@ -103,7 +103,7 @@ static void signalfx_memoize_alternate_prefix(zai_config_memoized_entry *memoize
 
 static void signalfx_memoize_alternates_names(zai_config_memoized_entry *memoized, zai_string_view *name, bool is_main) {
     if (is_main) {
-        signalfx_memoize_alternate_name(memoized, name, ZAI_STRL_VIEW("DD_TRACE_ENABLED"), 
+        signalfx_memoize_alternate_name(memoized, name, ZAI_STRL_VIEW("DD_TRACE_ENABLED"),
                                         ZAI_STRL_VIEW("SIGNALFX_TRACING_ENABLED"));
     }
 

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -89,6 +89,9 @@ void zai_config_rinit(void);
 // dtor run-time zvals  (--rc)
 void zai_config_rshutdown(void);
 
+// SIGNALFX: Replace DD default value with SFX default value (after zai_config_rinit)
+void zai_config_use_signalfx_default(zai_config_id id, zai_string_view default_value);
+
 // Directly replace the config value for the current request. Copies the passed argument.
 void zai_config_replace_runtime_config(zai_config_id id, zval *value);
 

--- a/zend_abstract_interface/signalfx/CMakeLists.txt
+++ b/zend_abstract_interface/signalfx/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(zai_signalfx json_writer.c)
+
+target_include_directories(
+    zai_signalfx PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                    $<INSTALL_INTERFACE:include>)
+
+target_compile_features(zai_signalfx PUBLIC c_std_99)
+
+target_link_libraries(zai_signalfx PUBLIC "${PHP_LIB}" dl)
+
+set_target_properties(zai_signalfx PROPERTIES EXPORT_NAME SignalFX
+                                            VERSION ${PROJECT_VERSION})
+
+add_library(Zai::SignalFX ALIAS zai_signalfx)
+
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/json_writer.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/signalfx/)
+
+target_link_libraries(zai_zend_abstract_interface INTERFACE zai_signalfx)
+
+install(TARGETS zai_signalfx EXPORT ZendAbstractInterfaceTargets)

--- a/zend_abstract_interface/signalfx/json_writer.c
+++ b/zend_abstract_interface/signalfx/json_writer.c
@@ -130,7 +130,7 @@ void json_writer_key_value_separator(json_writer_s *writer) {
 static bool json_writer_check_printf_result(json_writer_s *writer, int print_result) {
     if (print_result < 0) {
         if (writer->error == json_writer_error_ok) {
-            writer->error = json_writer_error_printf;   
+            writer->error = json_writer_error_printf;
         }
         return false;
     }
@@ -242,7 +242,7 @@ static utf8_advance_result_e utf8_advance(const uint8_t *buffer, size_t *chunk_l
                 return utf8_advance_error;
             }
 
-            uint32_t codepoint = utf8_point(byte0, ~0xF0, 12) | 
+            uint32_t codepoint = utf8_point(byte0, ~0xF0, 12) |
                 utf8_point(byte1, ~0xC0, 6) | utf8_point(byte2, ~0xC0, 0);
 
             if (codepoint < 0x80) {
@@ -266,13 +266,13 @@ static utf8_advance_result_e utf8_advance(const uint8_t *buffer, size_t *chunk_l
                 return utf8_advance_error;
             }
 
-            uint32_t codepoint = utf8_point(byte0, ~0xF8, 18) | utf8_point(byte1, ~0xC0, 12) | 
+            uint32_t codepoint = utf8_point(byte0, ~0xF8, 18) | utf8_point(byte1, ~0xC0, 12) |
                 utf8_point(byte2, ~0xC0, 6) | utf8_point(byte3, ~0xC0, 0);
 
             if (codepoint < 0x10000 || codepoint >= 0x10FFFF) {
                 return utf8_advance_error;
             }
-            
+
             cursor += 4;
         } else {
             return utf8_advance_error;


### PR DESCRIPTION
Previously the payload was already sent in JSON format, but the span object was still using DataDog specific attributes. This changes it so the attributes would match those sent by the previous fork, which is basically Zipkin format. This is done by building a new PHP array from the DD-specific serialized array, which is not the most efficient way possible, but should cause minimal issues with future sync with upstream.

Previous fork had added B3 propagation on our side, but upstream had actually implemented support for this already, so made B3 propagation default instead. Also removed sending DD-specific headers which were otherwise sent even with B3 propagation.

Since the fork is designed to function as an unmodified DataDog agent if `SIGNALFX_MODE` option is set to false, configuration defaults are not changed at their definitions, but during runtime if `SIGNALFX_MODE` is true.

Removed use of codecov orb in CI as it requires allowing that orb in CircleCI and then setting up some destination where coverage information can be uploaded. It doesn't seem reasonable to spend time on setting this up in our CI, thus it was removed. This may make the CI get further, but there may still be other compatibility issues, which I will investigate for the next PR, so CI passing is not a criteria for this PR yet, unless it fails specifically on the newly modified code.