### PR TITLE
Refork - rename extension internally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -819,7 +819,7 @@ jobs:
           name: Install .deb from artifacts
           command: |
             sudo dpkg -i ./build/packages/*$(if [ $(uname -m) = "aarch64" ]; then echo aarch64; else echo amd64; fi)*.deb
-            php --ri=ddtrace
+            php --ri=signalfx_tracing
       - run:
           name: Run phpt tests against shippable package
           command: |
@@ -1099,7 +1099,7 @@ jobs:
             cp ./pecl/datadog_trace-*.tgz ./datadog_trace.tgz
             sudo pecl install datadog_trace.tgz
             echo "extension=ddtrace.so" | sudo tee $(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}')/ddtrace.ini
-            php --ri=ddtrace
+            php --ri=signalfx_tracing
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2867,5 +2867,7 @@ workflows:
           name: "Static Analysis 80"
           docker_image: cimg/php:8.0
           scenario: opentracing10
-      - "Post-Install Hook":
-          requires: [ 'Prepare Code' ]
+      # SIGNALFX: Post-install hook tests disabled as it is not compatible with renamed extension, and there is no
+      # reason to fix it as SFX package only works through the installer script, not package
+      #- "Post-Install Hook":
+      #    requires: [ 'Prepare Code' ]

--- a/dockerfiles/verify_packages/installer/test_upgrade_from_legacy.sh
+++ b/dockerfiles/verify_packages/installer/test_upgrade_from_legacy.sh
@@ -19,10 +19,10 @@ php ./build/packages/datadog-setup.php --php-bin php
 assert_ddtrace_version "${new_version}"
 
 # Assert that there are no deprecation warnings from old ddtrace.request_init_hook
-if [ -z "$(php --ri ddtrace | grep 'use DD_TRACE_REQUEST_INIT_HOOK instead')" ]; then
+if [ -z "$(php --ri signalfx_tracing | grep 'use DD_TRACE_REQUEST_INIT_HOOK instead')" ]; then
     echo "\nOk: request init hook param has been updated\n"
 else
-    echo "\nError: request init hook param has not been updated\n---\n$(php --ri ddtrace)\n---\n"
+    echo "\nError: request init hook param has not been updated\n---\n$(php --ri signalfx_tracing)\n---\n"
     exit 1
 fi
 

--- a/dockerfiles/verify_packages/verify_rpm_centos6.sh
+++ b/dockerfiles/verify_packages/verify_rpm_centos6.sh
@@ -16,7 +16,7 @@ for phpVer in $(ls ${PHP_INSTALL_DIR}); do
     if [ "$INSTALL_TYPE" = "native_package" ]; then
         echo "Installing dd-trace-php using the OS-specific package installer"
         rpm -Uvh build/packages/*.rpm
-        php --ri=ddtrace
+        php --ri=signalfx_tracing
 
         # Uninstall the tracer
         rpm -e datadog-php-tracer

--- a/dockerfiles/verify_packages/verify_tar_gz_root.sh
+++ b/dockerfiles/verify_packages/verify_tar_gz_root.sh
@@ -26,6 +26,6 @@ echo "Permissions are correct"
 echo "Installing as per https://docs.datadoghq.com/tracing/faq/php-tracer-manual-installation/#automatic-ini-file-setup"
 /opt/datadog-php/bin/post-install.sh
 
-php --ri=ddtrace
+php --ri=signalfx_tracing
 
 echo ".tar.gz archive correctly installed"

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -60,10 +60,11 @@ static zend_module_entry *ddtrace_module;
 
 atomic_int ddtrace_warn_legacy_api;
 
-ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
+// SIGNALFX: renamed extension
+ZEND_DECLARE_MODULE_GLOBALS(signalfx_tracing)
 
 #ifdef COMPILE_DL_DDTRACE
-ZEND_GET_MODULE(ddtrace)
+ZEND_GET_MODULE(signalfx_tracing)
 #ifdef ZTS
 ZEND_TSRMLS_CACHE_DEFINE();
 #endif
@@ -478,7 +479,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
                            CONST_CS | CONST_PERSISTENT);
     REGISTER_INI_ENTRIES();
 
-    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("ddtrace"));
+    // SIGNALFX: renamed extension
+    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("signalfx_tracing"));
     if (ddtrace_module_zv) {
         ddtrace_module = Z_PTR_P(ddtrace_module_zv);
     }
@@ -506,8 +508,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
+        // SIGNALFX: renamed extension
         zend_error(E_CORE_WARNING,
-                   "Failed to find ddtrace extension in "
+                   "Failed to find signalfx_tracing extension in "
                    "registered modules. Please open a bug report.");
         return FAILURE;
     }
@@ -767,7 +770,7 @@ static int datadog_info_print(const char *str) { return php_output_write(str, st
 static void _dd_info_tracer_config(void) {
     smart_str buf = {0};
     ddtrace_startup_logging_json(&buf);
-    php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", ZSTR_VAL(buf.s));
+    php_info_print_table_row(2, "SIGNALFX TRACER CONFIGURATION", ZSTR_VAL(buf.s));
     smart_str_free(&buf);
 }
 

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -9,7 +9,7 @@
 
 // SIGNALFX: automagically fix some references to PHP module name ddtrace -> signalfx, allows making less changes to
 // code and not editing other source files at all that use ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
-#define ddtrace_globals_id signalfx_globals_id
+#define ddtrace_globals_id signalfx_tracing_globals_id
 #define zend_ddtrace_globals zend_signalfx_tracing_globals
 #define ddtrace_globals signalfx_tracing_globals
 #define ddtrace_module_entry signalfx_tracing_module_entry

--- a/ext/php7/ddtrace.h
+++ b/ext/php7/ddtrace.h
@@ -7,6 +7,18 @@
 #include "ext/version.h"
 #include "random.h"
 
+// SIGNALFX: automagically fix some references to PHP module name ddtrace -> signalfx, allows making less changes to
+// code and not editing other source files at all that use ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
+#define ddtrace_globals_id signalfx_globals_id
+#define zend_ddtrace_globals zend_signalfx_tracing_globals
+#define ddtrace_globals signalfx_tracing_globals
+#define ddtrace_module_entry signalfx_tracing_module_entry
+#define zm_startup_ddtrace zm_startup_signalfx_tracing
+#define zm_shutdown_ddtrace zm_shutdown_signalfx_tracing
+#define zm_activate_ddtrace zm_activate_signalfx_tracing
+#define zm_deactivate_ddtrace zm_deactivate_signalfx_tracing
+#define zm_info_ddtrace zm_info_signalfx_tracing
+
 extern zend_module_entry ddtrace_module_entry;
 extern zend_class_entry *ddtrace_ce_span_data;
 extern zend_class_entry *ddtrace_ce_fatal_error;
@@ -73,8 +85,10 @@ typedef struct {
     zend_string *message;
 } ddtrace_error_data;
 
+// SIGNALFX: renamed extension
+
 // clang-format off
-ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
+ZEND_BEGIN_MODULE_GLOBALS(signalfx_tracing)
     char *auto_prepend_file;
     uint8_t disable; // 0 = enabled, 1 = disabled via INI, 2 = disabled, but MINIT was fully executed
     zend_bool request_init_hook_loaded;
@@ -105,16 +119,16 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     zend_string *dd_origin;
 
     char *cgroup_file;
-ZEND_END_MODULE_GLOBALS(ddtrace)
+ZEND_END_MODULE_GLOBALS(signalfx_tracing)
 // clang-format on
 
 #ifdef ZTS
-#define DDTRACE_G(v) TSRMG(ddtrace_globals_id, zend_ddtrace_globals *, v)
+#define DDTRACE_G(v) TSRMG(signalfx_tracing_globals_id, zend_signalfx_tracing_globals *, v)
 #else
-#define DDTRACE_G(v) (ddtrace_globals.v)
+#define DDTRACE_G(v) (signalfx_tracing_globals.v)
 #endif
 
-#define PHP_DDTRACE_EXTNAME "ddtrace"
+#define PHP_DDTRACE_EXTNAME "signalfx_tracing"
 #ifndef PHP_DDTRACE_VERSION
 #define PHP_DDTRACE_VERSION "0.0.0-unknown"
 #endif

--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -380,9 +380,10 @@ void ddtrace_startup_logging_first_rinit(void) {
     _dd_serialize_json(ht, &buf);
     ddtrace_log_errf("DATADOG TRACER CONFIGURATION - %s", ZSTR_VAL(buf.s));
     ddtrace_log_errf(
-        "For additional diagnostic checks such as Agent connectivity, see the 'ddtrace' section of a phpinfo() "
-        "page. Alternatively set DD_TRACE_DEBUG=1 to add diagnostic checks to the error logs on the first request "
-        "of a new PHP process. Set DD_TRACE_STARTUP_LOGS=0 to disable this tracer configuration message.");
+        "For additional diagnostic checks such as Agent connectivity, see the 'signalfx_tracing' section of a "
+        "phpinfo() page. Alternatively set SIGNALFX_TRACE_DEBUG=1 to add diagnostic checks to the error logs on the "
+        "first request of a new PHP process. Set DD_TRACE_STARTUP_LOGS=0 to disable this tracer configuration "
+        "message.");
     smart_str_free(&buf);
 
     zend_hash_destroy(ht);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -64,10 +64,11 @@ static int dd_observer_extension_backup = -1;
 
 atomic_int ddtrace_warn_legacy_api;
 
-ZEND_DECLARE_MODULE_GLOBALS(ddtrace)
+// SIGNALFX: renamed extension
+ZEND_DECLARE_MODULE_GLOBALS(signalfx_tracing)
 
 #ifdef COMPILE_DL_DDTRACE
-ZEND_GET_MODULE(ddtrace)
+ZEND_GET_MODULE(signalfx_tracing)
 #ifdef ZTS
 ZEND_TSRMLS_CACHE_DEFINE();
 #endif
@@ -450,7 +451,8 @@ static PHP_MINIT_FUNCTION(ddtrace) {
                            CONST_CS | CONST_PERSISTENT);
     REGISTER_INI_ENTRIES();
 
-    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("ddtrace"));
+    // SIGNALFX: renamed extension
+    zval *ddtrace_module_zv = zend_hash_str_find(&module_registry, ZEND_STRL("signalfx_tracing"));
     if (ddtrace_module_zv) {
         ddtrace_module = Z_PTR_P(ddtrace_module_zv);
     }
@@ -478,8 +480,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         zend_hash_str_find_ptr(&module_registry, PHP_DDTRACE_EXTNAME, sizeof(PHP_DDTRACE_EXTNAME) - 1);
     if (mod_ptr == NULL) {
         // This shouldn't happen, possibly a bug if it does.
+        // SIGNALFX: renamed extension
         zend_error(E_CORE_WARNING,
-                   "Failed to find ddtrace extension in "
+                   "Failed to find signalfx_tracing extension in "
                    "registered modules. Please open a bug report.");
 
         return FAILURE;
@@ -756,7 +759,7 @@ static int datadog_info_print(const char *str) { return php_output_write(str, st
 static void _dd_info_tracer_config(void) {
     smart_str buf = {0};
     ddtrace_startup_logging_json(&buf);
-    php_info_print_table_row(2, "DATADOG TRACER CONFIGURATION", ZSTR_VAL(buf.s));
+    php_info_print_table_row(2, "SIGNALFX TRACER CONFIGURATION", ZSTR_VAL(buf.s));
     smart_str_free(&buf);
 }
 

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -9,7 +9,7 @@
 
 // SIGNALFX: automagically fix some references to PHP module name ddtrace -> signalfx, allows making less changes to
 // code and not editing other source files at all that use ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
-#define ddtrace_globals_id signalfx_globals_id
+#define ddtrace_globals_id signalfx_tracing_globals_id
 #define zend_ddtrace_globals zend_signalfx_tracing_globals
 #define ddtrace_globals signalfx_tracing_globals
 #define ddtrace_module_entry signalfx_tracing_module_entry

--- a/ext/php8/ddtrace.h
+++ b/ext/php8/ddtrace.h
@@ -7,6 +7,18 @@
 #include "ext/version.h"
 #include "random.h"
 
+// SIGNALFX: automagically fix some references to PHP module name ddtrace -> signalfx, allows making less changes to
+// code and not editing other source files at all that use ZEND_EXTERN_MODULE_GLOBALS(ddtrace)
+#define ddtrace_globals_id signalfx_globals_id
+#define zend_ddtrace_globals zend_signalfx_tracing_globals
+#define ddtrace_globals signalfx_tracing_globals
+#define ddtrace_module_entry signalfx_tracing_module_entry
+#define zm_startup_ddtrace zm_startup_signalfx_tracing
+#define zm_shutdown_ddtrace zm_shutdown_signalfx_tracing
+#define zm_activate_ddtrace zm_activate_signalfx_tracing
+#define zm_deactivate_ddtrace zm_deactivate_signalfx_tracing
+#define zm_info_ddtrace zm_info_signalfx_tracing
+
 extern zend_module_entry ddtrace_module_entry;
 extern zend_class_entry *ddtrace_ce_span_data;
 extern zend_class_entry *ddtrace_ce_fatal_error;
@@ -73,8 +85,10 @@ typedef struct {
     zend_string *message;
 } ddtrace_error_data;
 
+// SIGNALFX: renamed extension
+
 // clang-format off
-ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
+ZEND_BEGIN_MODULE_GLOBALS(signalfx_tracing)
     char *auto_prepend_file;
     uint8_t disable; // 0 = enabled, 1 = disabled via INI, 2 = disabled, but MINIT was fully executed
     zend_bool request_init_hook_loaded;
@@ -105,16 +119,16 @@ ZEND_BEGIN_MODULE_GLOBALS(ddtrace)
     zend_string *dd_origin;
 
     char *cgroup_file;
-ZEND_END_MODULE_GLOBALS(ddtrace)
+ZEND_END_MODULE_GLOBALS(signalfx_tracing)
 // clang-format on
 
 #ifdef ZTS
-#define DDTRACE_G(v) TSRMG(ddtrace_globals_id, zend_ddtrace_globals *, v)
+#define DDTRACE_G(v) TSRMG(signalfx_tracing_globals_id, zend_signalfx_tracing_globals *, v)
 #else
-#define DDTRACE_G(v) (ddtrace_globals.v)
+#define DDTRACE_G(v) (signalfx_tracing_globals.v)
 #endif
 
-#define PHP_DDTRACE_EXTNAME "ddtrace"
+#define PHP_DDTRACE_EXTNAME "signalfx_tracing"
 #ifndef PHP_DDTRACE_VERSION
 #define PHP_DDTRACE_VERSION "0.0.0-unknown"
 #endif

--- a/ext/php8/startup_logging.c
+++ b/ext/php8/startup_logging.c
@@ -380,9 +380,9 @@ void ddtrace_startup_logging_first_rinit(void) {
     _dd_serialize_json(ht, &buf);
     ddtrace_log_errf("DATADOG TRACER CONFIGURATION - %s", ZSTR_VAL(buf.s));
     ddtrace_log_errf(
-        "For additional diagnostic checks such as Agent connectivity, see the 'ddtrace' section of a phpinfo() "
-        "page. Alternatively set DD_TRACE_DEBUG=1 to add diagnostic checks to the error logs on the first request "
-        "of a new PHP process. Set DD_TRACE_STARTUP_LOGS=0 to disable this tracer configuration message.");
+        "For additional diagnostic checks such as Agent connectivity, see the 'signalfx_tracing' section of a "
+        "phpinfo() page. Alternatively set DD_TRACE_DEBUG=1 to add diagnostic checks to the error logs on the first "
+        "request of a new PHP process. Set DD_TRACE_STARTUP_LOGS=0 to disable this tracer configuration message.");
     smart_str_free(&buf);
 
     zend_hash_destroy(ht);

--- a/package/post-install.sh
+++ b/package/post-install.sh
@@ -156,7 +156,7 @@ function fail_print_and_exit() {
 }
 
 function verify_installation() {
-    invoke_php -m | grep -e "^ddtrace$" && \
+    invoke_php -m | grep -e "^signalfx_tracing$" && \
         println "Extension enabled successfully" || \
         fail_print_and_exit
 }

--- a/src/Integrations/Integrations/Integration.php
+++ b/src/Integrations/Integrations/Integration.php
@@ -117,7 +117,7 @@ abstract class Integration
      */
     public static function shouldLoad($name)
     {
-        if (!\extension_loaded('ddtrace')) {
+        if (!\extension_loaded('signalfx_tracing')) {
             \trigger_error('ddtrace extension required to load integration.', \E_USER_WARNING);
             return false;
         }

--- a/src/Integrations/Integrations/IntegrationsLoader.php
+++ b/src/Integrations/Integrations/IntegrationsLoader.php
@@ -135,7 +135,7 @@ class IntegrationsLoader
      */
     public function loadAll()
     {
-        if (!extension_loaded('ddtrace')) {
+        if (!extension_loaded('signalfx_tracing')) {
             trigger_error(
                 'Missing ddtrace extension. To disable tracing set env variable DD_TRACE_ENABLED=false',
                 E_USER_WARNING

--- a/src/api/GlobalTracer.php
+++ b/src/api/GlobalTracer.php
@@ -44,7 +44,7 @@ final class GlobalTracer
         }
 
         // Ensure that, when trying to use the legacy API, our Tracer is also loaded
-        if (\extension_loaded('ddtrace') && function_exists('ddtrace_legacy_tracer_autoloading_possible')) {
+        if (\extension_loaded('signalfx_tracing') && function_exists('ddtrace_legacy_tracer_autoloading_possible')) {
             /** @phpstan-ignore-next-line */
             return self::$instance = new Tracer();
         }

--- a/tests/PostInstallHook/run-tests.sh
+++ b/tests/PostInstallHook/run-tests.sh
@@ -44,13 +44,13 @@ function showStatus() {
 }
 
 function testInstalled() {
-    printf "  %s; %s ddtrace installed " "$1" "$2"
+    printf "  %s; %s signalfx_tracing installed " "$1" "$2"
     php "$pwd/test-installed.php" --php-version "$1" --sapi "$2"
     showStatus $?
 }
 
 function testNotInstalled() {
-    printf "  %s; %s ddtrace NOT installed " "$1" "$2"
+    printf "  %s; %s signalfx_tracing NOT installed " "$1" "$2"
     php "$pwd/test-not-installed.php" --php-version "$1" --sapi "$2"
     showStatus $?
 }
@@ -62,7 +62,7 @@ function checkIsInstalledCli() {
         bin="/usr/bin/php$defaultPhpVersion"
     fi
     printf "  %s; cli " "$bin"
-    $bin --ri=ddtrace > /dev/null 2>&1
+    $bin --ri=signalfx_tracing > /dev/null 2>&1
 }
 
 function testInstalledCli() {

--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -69,7 +69,7 @@ function call_function(ReflectionFunction $function)
 
 function runOneIteration()
 {
-    $ext = new ReflectionExtension("ddtrace");
+    $ext = new ReflectionExtension("signalfx_tracing");
     $functions = array_filter($ext->getFunctions(), function ($f) {
         return $f->name != "dd_trace_internal_fn"
             && !strpos($f->name, "Testing")

--- a/tests/randomized/app/src/RandomizedTests/RandomExecutionPath.php
+++ b/tests/randomized/app/src/RandomizedTests/RandomExecutionPath.php
@@ -34,7 +34,7 @@ class RandomExecutionPath
 
         // Do not use function_exists('DDTrace\...') because if DD_TRACE_ENABLED is not false and the function does not
         // exist then we MUST generate an error
-        if (getenv('DD_TRACE_ENABLED') !== 'false' && extension_loaded('ddtrace')) {
+        if (getenv('DD_TRACE_ENABLED') !== 'false' && extension_loaded('signalfx_tracing')) {
             // Tracing manual functions
             $callback = function (\DDTrace\SpanData $span) {
                 $span->service = \ddtrace_config_app_name();


### PR DESCRIPTION
This renames the PHP module that the extension registers from `ddtrace` to `signalfx_tracing`. PHP does not require file names to match the module name, therefore there should be no issue with the file still being named `ddtrace.so` for tests and only updated to `signalfx_tracing.so` for final packaging.