### PR TITLE
Refork - Set SIGNALFX_MODE enabled by default if library name is not ddtrace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2457,8 +2457,9 @@ workflows:
                 - php_installer
                 - native_package
               docker_image:
-                - alpine:3.7
-                - alpine:3.8
+                # SIGNALFX: 3.7 and 3.8 disabled for now as the method to set SIGNALFX_MODE=0 automatically doesn't work on these
+                #- alpine:3.7
+                #- alpine:3.8
                 - alpine:3.9
                 - alpine:3.9
                 - alpine:3.10
@@ -2474,7 +2475,8 @@ workflows:
                 - php_installer
                 - native_package
               docker_image:
-                - php:7.0-fpm-alpine
+                # SIGNALFX: 7.0 disabled, see above comment on alpine 3.7/3.8
+                #- php:7.0-fpm-alpine
                 - php:7.1-fpm-alpine
                 - php:7.2-fpm-alpine
                 - php:7.3-fpm-alpine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2440,7 +2440,8 @@ workflows:
                 - php_installer
                 - native_package
               docker_image:
-                - alpine:3.8
+                # SIGNALFX: 3.8 disabled for now as the method to set SIGNALFX_MODE=0 automatically doesn't work on these
+                #- alpine:3.8
                 - alpine:3.9
                 - alpine:3.10
                 - alpine:3.11
@@ -2457,7 +2458,7 @@ workflows:
                 - php_installer
                 - native_package
               docker_image:
-                # SIGNALFX: 3.7 and 3.8 disabled for now as the method to set SIGNALFX_MODE=0 automatically doesn't work on these
+                # SIGNALFX: 3.7 and 3.8 disabled, see above comment on alpine 3.8
                 #- alpine:3.7
                 #- alpine:3.8
                 - alpine:3.9

--- a/config.m4
+++ b/config.m4
@@ -107,6 +107,7 @@ if test "$PHP_DDTRACE" != "no"; then
       zend_abstract_interface/interceptor/php7/resolver.c \
       zend_abstract_interface/json/json.c \
       zend_abstract_interface/signalfx/json_writer.c \
+      zend_abstract_interface/signalfx/signalfx.c \
       zend_abstract_interface/symbols/lookup.c \
       zend_abstract_interface/symbols/call.c \
       zend_abstract_interface/sandbox/php7/sandbox.c \
@@ -167,6 +168,7 @@ if test "$PHP_DDTRACE" != "no"; then
       zend_abstract_interface/interceptor/php8/resolver.c \
       zend_abstract_interface/json/json.c \
       zend_abstract_interface/signalfx/json_writer.c \
+      zend_abstract_interface/signalfx/signalfx.c \
       zend_abstract_interface/symbols/lookup.c \
       zend_abstract_interface/symbols/call.c \
       zend_abstract_interface/sandbox/php8/sandbox.c \

--- a/ext/php7/auto_flush.c
+++ b/ext/php7/auto_flush.c
@@ -53,7 +53,9 @@ ZEND_RESULT_CODE ddtrace_flush_tracer() {
 
     // SIGNALFX: serialize with JSON and without wrapping an additional array around it
     if (get_global_SIGNALFX_MODE()) {
-        return ddtrace_flush_tracer_json(&trace) ? SUCCESS : FAILURE;
+        success = ddtrace_flush_tracer_json(&trace);
+        zend_array_destroy(Z_ARR(trace));
+        return success ? SUCCESS : FAILURE;
     }
 
     // background sender only wants a singular trace

--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -60,7 +60,7 @@ extern bool runtime_config_first_init;
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
     /* SIGNALFX: add SignalFX specific configuration options */                                                \
-    CONFIG(BOOL, SIGNALFX_MODE, "false")                                                                       \
+    CONFIG(BOOL, SIGNALFX_MODE, "true")                                                                        \
     CONFIG(STRING, SIGNALFX_ENDPOINT_URL, "")                                                                  \
     CONFIG(STRING, SIGNALFX_ENDPOINT_HOST, "localhost")                                                        \
     CONFIG(STRING, SIGNALFX_ENDPOINT_PORT, "9080")                                                             \

--- a/ext/php7/handlers_curl.c
+++ b/ext/php7/handlers_curl.c
@@ -150,9 +150,12 @@ static int dd_inject_distributed_tracing_headers(zval *ch) {
     }
     zend_string *propagated_tags = ddtrace_format_propagated_tags();
     // SIGNALFX: do not send DD tags header if SFX mode is enabled
-    if (propagated_tags && !get_global_SIGNALFX_MODE()) {
-        add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-tags: %s", ZSTR_VAL(propagated_tags)));
-        zend_string_release(propagated_tags);
+    if (!get_global_SIGNALFX_MODE()) {
+        zend_string *propagated_tags = ddtrace_format_propagated_tags();
+        if (propagated_tags) {
+            add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-tags: %s", ZSTR_VAL(propagated_tags)));
+            zend_string_release(propagated_tags);
+        }
     }
     uint64_t trace_id = ddtrace_peek_trace_id(), span_id = ddtrace_peek_span_id();
     if (trace_id) {

--- a/ext/php7/handlers_curl.c
+++ b/ext/php7/handlers_curl.c
@@ -148,7 +148,6 @@ static int dd_inject_distributed_tracing_headers(zval *ch) {
             }
         }
     }
-    zend_string *propagated_tags = ddtrace_format_propagated_tags();
     // SIGNALFX: do not send DD tags header if SFX mode is enabled
     if (!get_global_SIGNALFX_MODE()) {
         zend_string *propagated_tags = ddtrace_format_propagated_tags();

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -1058,7 +1058,7 @@ static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span
         zval *dd_service = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("service"));
 
         if (dd_service != NULL && Z_TYPE_P(dd_service) == IS_STRING) {
-            add_assoc_zval(tags, SFX_TAG_COMPONENT, dd_service);
+            _add_assoc_zval_copy(tags, SFX_TAG_COMPONENT, dd_service);
         }
     }
 
@@ -1069,7 +1069,7 @@ static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span
 
         if (dd_resource != NULL && Z_TYPE_P(dd_resource) == IS_STRING) {
             if (name_cstr == NULL || strcmp(name_cstr, Z_STRVAL_P(dd_resource)) != 0) {
-                add_assoc_zval(tags, SFX_TAG_RESOURCE_NAME, dd_resource);
+                _add_assoc_zval_copy(tags, SFX_TAG_RESOURCE_NAME, dd_resource);
             }
         }
     }

--- a/ext/php8/auto_flush.c
+++ b/ext/php8/auto_flush.c
@@ -53,7 +53,9 @@ ZEND_RESULT_CODE ddtrace_flush_tracer() {
 
     // SIGNALFX: serialize with JSON and without wrapping an additional array around it
     if (get_global_SIGNALFX_MODE()) {
-        return ddtrace_flush_tracer_json(&trace) ? SUCCESS : FAILURE;
+        success = ddtrace_flush_tracer_json(&trace);
+        zend_array_destroy(Z_ARR(trace));
+        return success ? SUCCESS : FAILURE;
     }
 
     // background sender only wants a singular trace

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -60,7 +60,7 @@ extern bool runtime_config_first_init;
     CALIAS(STRING, DD_TRACE_REQUEST_INIT_HOOK, DD_DEFAULT_REQUEST_INIT_HOOK_PATH,                              \
            CALIASES("DDTRACE_REQUEST_INIT_HOOK"), .ini_change = zai_config_system_ini_change)                  \
     /* SIGNALFX: add SignalFX specific configuration options */                                                \
-    CONFIG(BOOL, SIGNALFX_MODE, "false")                                                                       \
+    CONFIG(BOOL, SIGNALFX_MODE, "true")                                                                        \
     CONFIG(STRING, SIGNALFX_ENDPOINT_URL, "")                                                                  \
     CONFIG(STRING, SIGNALFX_ENDPOINT_HOST, "localhost")                                                        \
     CONFIG(STRING, SIGNALFX_ENDPOINT_PORT, "9080")                                                             \

--- a/ext/php8/handlers_curl.c
+++ b/ext/php8/handlers_curl.c
@@ -98,11 +98,13 @@ static void dd_inject_distributed_tracing_headers(zend_object *ch) {
             }
         }
     }
-    zend_string *propagated_tags = ddtrace_format_propagated_tags();
     // SIGNALFX: do not send DD tags header if SFX mode is enabled
-    if (propagated_tags && !get_global_SIGNALFX_MODE()) {
-        add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-tags: %s", ZSTR_VAL(propagated_tags)));
-        zend_string_release(propagated_tags);
+    if (!get_global_SIGNALFX_MODE()) {
+        zend_string *propagated_tags = ddtrace_format_propagated_tags();
+        if (propagated_tags) {
+            add_next_index_str(&headers, zend_strpprintf(0, "x-datadog-tags: %s", ZSTR_VAL(propagated_tags)));
+            zend_string_release(propagated_tags);
+        }
     }
     uint64_t trace_id = ddtrace_peek_trace_id(), span_id = ddtrace_peek_span_id();
     if (trace_id) {

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -1057,7 +1057,7 @@ static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span
         zval *dd_service = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("service"));
 
         if (dd_service != NULL && Z_TYPE_P(dd_service) == IS_STRING) {
-            add_assoc_zval(tags, SFX_TAG_COMPONENT, dd_service);
+            _add_assoc_zval_copy(tags, SFX_TAG_COMPONENT, dd_service);
         }
     }
 
@@ -1068,7 +1068,7 @@ static void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span
 
         if (dd_resource != NULL && Z_TYPE_P(dd_resource) == IS_STRING) {
             if (name_cstr == NULL || strcmp(name_cstr, Z_STRVAL_P(dd_resource)) != 0) {
-                add_assoc_zval(tags, SFX_TAG_RESOURCE_NAME, dd_resource);
+                _add_assoc_zval_copy(tags, SFX_TAG_RESOURCE_NAME, dd_resource);
             }
         }
     }

--- a/zend_abstract_interface/CMakeLists.txt
+++ b/zend_abstract_interface/CMakeLists.txt
@@ -91,6 +91,9 @@ if(NOT TARGET Tea::Tea)
   message(FATAL_ERROR "TEA is required but not found")
 endif()
 
+# SIGNALFX: directory for signalfx specific ZAI source files
+add_subdirectory(signalfx)
+
 add_subdirectory(env)
 add_subdirectory(exceptions)
 add_subdirectory(config)
@@ -103,8 +106,6 @@ add_subdirectory(sandbox)
 add_subdirectory(uri_normalization)
 add_subdirectory(zai_string)
 add_subdirectory(zai_assert)
-# SIGNALFX: directory for signalfx specific ZAI source files
-add_subdirectory(signalfx)
 
 install(
   EXPORT ZendAbstractInterfaceTargets

--- a/zend_abstract_interface/config/CMakeLists.txt
+++ b/zend_abstract_interface/config/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(
 
 target_compile_features(zai_config PUBLIC c_std_99)
 
-target_link_libraries(zai_config PUBLIC "${PHP_LIB}" Zai::Env)
+target_link_libraries(zai_config PUBLIC "${PHP_LIB}" Zai::Env Zai::SignalFX)
 
 set_target_properties(zai_config PROPERTIES EXPORT_NAME Config
                                             VERSION ${PROJECT_VERSION})

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -151,7 +151,7 @@ static zai_config_memoized_entry *zai_config_memoize_entry(zai_config_entry *ent
     }
 
     ZVAL_UNDEF(&memoized->decoded_value);
-    if (!zai_config_decode_value(entry->default_encoded_value, memoized->type, &memoized->decoded_value,
+    if (!zai_config_decode_value(memoized->default_encoded_value, memoized->type, &memoized->decoded_value,
                                  /* persistent */ true)) {
         assert(0 && "Error decoding default value");
     }

--- a/zend_abstract_interface/signalfx/CMakeLists.txt
+++ b/zend_abstract_interface/signalfx/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(zai_signalfx json_writer.c)
+add_library(zai_signalfx json_writer.c signalfx.c)
 
 target_include_directories(
     zai_signalfx PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -15,6 +15,7 @@ add_library(Zai::SignalFX ALIAS zai_signalfx)
 
 install(
   FILES ${CMAKE_CURRENT_SOURCE_DIR}/json_writer.h
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/signalfx.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/signalfx/)
 
 target_link_libraries(zai_zend_abstract_interface INTERFACE zai_signalfx)

--- a/zend_abstract_interface/signalfx/signalfx.c
+++ b/zend_abstract_interface/signalfx/signalfx.c
@@ -5,12 +5,14 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 bool signalfx_detect_ddtrace_mode(void) {
     const char* env_variable = getenv("SIGNALFX_MODE");
 
     if (env_variable != NULL) {
-        return strcmp(env_variable, "0") == 0 || strcmp(env_variable, "false") == 0;
+        return strcmp(env_variable, "0") == 0 || strcasecmp(env_variable, "false") == 0 ||
+               strcasecmp(env_variable, "off") == 0 || strcasecmp(env_variable, "no") == 0;
     }
 
     Dl_info lookup;

--- a/zend_abstract_interface/signalfx/signalfx.c
+++ b/zend_abstract_interface/signalfx/signalfx.c
@@ -1,0 +1,24 @@
+#include "signalfx.h"
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+bool signalfx_detect_ddtrace_mode(void) {
+    const char* env_variable = getenv("SIGNALFX_MODE");
+
+    if (env_variable != NULL) {
+        return strcmp(env_variable, "0") == 0 || strcmp(env_variable, "false") == 0;
+    }
+    
+    Dl_info lookup;
+    if (dladdr(&signalfx_detect_ddtrace_mode, &lookup) != 0) {
+        if (strstr(lookup.dli_fname, "ddtrace") != NULL) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/zend_abstract_interface/signalfx/signalfx.c
+++ b/zend_abstract_interface/signalfx/signalfx.c
@@ -12,7 +12,7 @@ bool signalfx_detect_ddtrace_mode(void) {
     if (env_variable != NULL) {
         return strcmp(env_variable, "0") == 0 || strcmp(env_variable, "false") == 0;
     }
-    
+
     Dl_info lookup;
     if (dladdr(&signalfx_detect_ddtrace_mode, &lookup) != 0) {
         if (strstr(lookup.dli_fname, "ddtrace") != NULL) {

--- a/zend_abstract_interface/signalfx/signalfx.c
+++ b/zend_abstract_interface/signalfx/signalfx.c
@@ -7,6 +7,10 @@
 #include <string.h>
 #include <strings.h>
 
+// Need this to take dladdr of it. On certain musl versions, trying to dladdr signalfx_detect_ddtrace_mode itself
+// segfaults, but this option works fine.
+static int dummy_static_variable = 0;
+
 bool signalfx_detect_ddtrace_mode(void) {
     const char* env_variable = getenv("SIGNALFX_MODE");
 
@@ -16,7 +20,7 @@ bool signalfx_detect_ddtrace_mode(void) {
     }
 
     Dl_info lookup;
-    if (dladdr(&signalfx_detect_ddtrace_mode, &lookup) != 0) {
+    if (dladdr(&dummy_static_variable, &lookup) != 0) {
         if (strstr(lookup.dli_fname, "ddtrace") != NULL) {
             return true;
         }

--- a/zend_abstract_interface/signalfx/signalfx.h
+++ b/zend_abstract_interface/signalfx/signalfx.h
@@ -1,0 +1,10 @@
+#ifndef ZAI_SIGNALFX_SIGNALFX_H
+#define ZAI_SIGNALFX_SIGNALFX_H
+
+#include <stdbool.h>
+
+// SIGNALFX: detect if running with the shared library being named ddtrace.so as that means this execution is only
+// for tests and SIGNALFX_MODE should be disabled by default (but can be enabled)
+bool signalfx_detect_ddtrace_mode(void);
+
+#endif


### PR DESCRIPTION
There are a lot of tests that depend on the DataDog exporter in a way that can't be easily adjusted for SignalFX (Zipkin) exporter. Specifically there is an additional layer of arrays when exporting which does not exist for Zipkin, and thus basically all tests that check data from exporter would have to be changed. Due to this, most tests will continue running the agent in "ddtrace mode", which means it keeps using the DataDog exporter.

To facilitate this, there is a "SIGNALFX_MODE" configuration option, which is disabled by default only if the dynamic library name contains 'ddtrace' in its name (as the `signalfx_tracing.so` is only used for final packaging, intermediate builds and tests keep using `ddtrace.so`). This means we don't have to update every place where tests are launched to inject the configuration option for them, while making sure we cannot accidentally omit this in "production mode" where the shared library name will be `signalfx_tracing.so`.