### PR TITLE
Refork - add component tag to integrations

### DIFF
--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -643,6 +643,12 @@ static void signalfx_set_meta_component(zend_array *meta, const char *component,
     zend_hash_str_add_new(meta, ZEND_STRL("component"), &component_zv);
 }
 
+// SIGNALFX: set autoroot properties
+void signalfx_set_autoroot_properties(ddtrace_span_t *span) {
+    zend_array *meta = ddtrace_spandata_property_meta(span);
+    signalfx_set_meta_component(meta, ZEND_STRL("web.request"));
+}
+
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
@@ -735,9 +741,6 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));
     }
 
-    // SIGNALFX: set component tag
-    signalfx_set_meta_component(meta, ZEND_STRL("web.request"));
-    
     zval *prop_service = ddtrace_spandata_property_service(span);
     ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
 

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -636,6 +636,13 @@ static zend_string *dd_get_user_agent() {
     return ZSTR_EMPTY_ALLOC();
 }
 
+// SIGNALFX: function to add component tag to root span
+static void signalfx_set_meta_component(zend_array *meta, const char *component, size_t component_length) {
+    zval component_zv;
+    ZVAL_STR(&component_zv, zend_string_init(component, component_length, 0));
+    zend_hash_str_add_new(meta, ZEND_STRL("component"), &component_zv);
+}
+
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
@@ -727,6 +734,10 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("web"), 0));
         ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));
     }
+
+    // SIGNALFX: set component tag
+    signalfx_set_meta_component(meta, ZEND_STRL("web.request"));
+    
     zval *prop_service = ddtrace_spandata_property_service(span);
     ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
 

--- a/ext/php7/serializer.h
+++ b/ext/php7/serializer.h
@@ -12,6 +12,8 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array);
 void ddtrace_save_active_error_to_metadata(void);
 void ddtrace_set_global_span_properties(ddtrace_span_t *span);
 void ddtrace_set_root_span_properties(ddtrace_span_t *span);
+// SIGNALFX: set autoroot properties
+void signalfx_set_autoroot_properties(ddtrace_span_t *span);
 
 void ddtrace_initialize_span_sampling_limiter(void);
 void ddtrace_shutdown_span_sampling_limiter(void);

--- a/ext/php7/span.c
+++ b/ext/php7/span.c
@@ -81,6 +81,10 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci) {
     if (!span_fci->next) {  // root span
         span->chunk_root = span_fci;
         ddtrace_set_root_span_properties(&span_fci->span);
+        // SIGNALFX: sfx custom root properties are only set for autoroot
+        if (span_fci->type == DDTRACE_AUTOROOT_SPAN) {
+            signalfx_set_autoroot_properties(&span_fci->span);
+        }
     } else {
         ddtrace_span_fci *next_span = span_fci->next;
         span->chunk_root = next_span->span.chunk_root;

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -642,6 +642,12 @@ static void signalfx_set_meta_component(zend_array *meta, const char *component,
     zend_hash_str_add_new(meta, ZEND_STRL("component"), &component_zv);
 }
 
+// SIGNALFX: set autoroot properties
+void signalfx_set_autoroot_properties(ddtrace_span_t *span) {
+    zend_array *meta = ddtrace_spandata_property_meta(span);
+    signalfx_set_meta_component(meta, ZEND_STRL("web.request"));
+}
+
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
@@ -734,9 +740,6 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));
     }
 
-    // SIGNALFX: set component tag
-    signalfx_set_meta_component(meta, ZEND_STRL("web.request"));
-    
     zval *prop_service = ddtrace_spandata_property_service(span);
     ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
 

--- a/ext/php8/serializer.c
+++ b/ext/php8/serializer.c
@@ -635,6 +635,13 @@ static zend_string *dd_get_user_agent() {
     return zend_empty_string;
 }
 
+// SIGNALFX: function to add component tag to root span
+static void signalfx_set_meta_component(zend_array *meta, const char *component, size_t component_length) {
+    zval component_zv;
+    ZVAL_STR(&component_zv, zend_string_init(component, component_length, 0));
+    zend_hash_str_add_new(meta, ZEND_STRL("component"), &component_zv);
+}
+
 void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
     zend_array *meta = ddtrace_spandata_property_meta(span);
 
@@ -726,6 +733,10 @@ void ddtrace_set_root_span_properties(ddtrace_span_t *span) {
         ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("web"), 0));
         ZVAL_STR(prop_name, zend_string_init(ZEND_STRL("web.request"), 0));
     }
+
+    // SIGNALFX: set component tag
+    signalfx_set_meta_component(meta, ZEND_STRL("web.request"));
+    
     zval *prop_service = ddtrace_spandata_property_service(span);
     ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
 

--- a/ext/php8/serializer.h
+++ b/ext/php8/serializer.h
@@ -12,6 +12,8 @@ void ddtrace_serialize_span_to_array(ddtrace_span_fci *span_fci, zval *array);
 void ddtrace_save_active_error_to_metadata(void);
 void ddtrace_set_global_span_properties(ddtrace_span_t *span);
 void ddtrace_set_root_span_properties(ddtrace_span_t *span);
+// SIGNALFX: set autoroot properties
+void signalfx_set_autoroot_properties(ddtrace_span_t *span);
 
 void ddtrace_initialize_span_sampling_limiter(void);
 void ddtrace_shutdown_span_sampling_limiter(void);

--- a/ext/php8/span.c
+++ b/ext/php8/span.c
@@ -81,6 +81,10 @@ void ddtrace_open_span(ddtrace_span_fci *span_fci) {
     if (!span_fci->next) {  // root span
         span->chunk_root = span_fci;
         ddtrace_set_root_span_properties(&span_fci->span);
+        // SIGNALFX: sfx custom root properties are only set for autoroot
+        if (span_fci->type == DDTRACE_AUTOROOT_SPAN) {
+            signalfx_set_autoroot_properties(&span_fci->span);
+        }
     } else {
         ddtrace_span_fci *next_span = span_fci->next;
         span->chunk_root = next_span->span.chunk_root;

--- a/src/Integrations/Integrations/CakePHP/CakePHPIntegration.php
+++ b/src/Integrations/Integrations/CakePHP/CakePHPIntegration.php
@@ -47,6 +47,7 @@ class CakePHPIntegration extends Integration
         $integration->appName = \ddtrace_config_app_name(CakePHPIntegration::NAME);
         $integration->rootSpan = $rootSpan;
         $integration->addTraceAnalyticsIfEnabled($integration->rootSpan);
+        $integration->rootSpan->meta[Tag::COMPONENT] = 'cakephp';
         $integration->rootSpan->service = $integration->appName;
         if ('cli' === PHP_SAPI) {
             $integration->rootSpan->name = 'cakephp.console';
@@ -63,6 +64,7 @@ class CakePHPIntegration extends Integration
                 $span->name = $span->resource = 'Controller.invokeAction';
                 $span->type = Type::WEB_SERVLET;
                 $span->service = $integration->appName;
+                $span->meta[Tag::COMPONENT] = 'cakephp';
 
                 $request = $args[0];
                 if (!$request instanceof CakeRequest) {
@@ -114,6 +116,7 @@ class CakePHPIntegration extends Integration
             $file = $this->viewPath . '/' . $this->view . $this->ext;
             $span->resource = $file;
             $span->meta = ['cakephp.view' => $file];
+            $span->meta[Tag::COMPONENT] = 'cakephp';
             $span->service = $integration->appName;
         });
 

--- a/src/Integrations/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
+++ b/src/Integrations/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
@@ -52,7 +52,7 @@ class CodeIgniterIntegration extends Integration
         $rootSpan->name = 'codeigniter.request';
         $rootSpan->service = $service;
         $rootSpan->type = Type::WEB_SERVLET;
-        $span->meta[Tag::COMPONENT] = 'codeigniter';
+        $rootSpan->meta[Tag::COMPONENT] = 'codeigniter';
 
         if ('cli' !== PHP_SAPI) {
             $normalizedPath = \DDTrace\Util\Normalizer::uriNormalizeincomingPath($_SERVER['REQUEST_URI']);

--- a/src/Integrations/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
+++ b/src/Integrations/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
@@ -52,6 +52,7 @@ class CodeIgniterIntegration extends Integration
         $rootSpan->name = 'codeigniter.request';
         $rootSpan->service = $service;
         $rootSpan->type = Type::WEB_SERVLET;
+        $span->meta[Tag::COMPONENT] = 'codeigniter';
 
         if ('cli' !== PHP_SAPI) {
             $normalizedPath = \DDTrace\Util\Normalizer::uriNormalizeincomingPath($_SERVER['REQUEST_URI']);
@@ -69,6 +70,7 @@ class CodeIgniterIntegration extends Integration
                 $span->name = $span->resource = "{$class}.{$method}";
                 $span->service = $service;
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
 
                 $this->load->helper('url');
 
@@ -97,6 +99,7 @@ class CodeIgniterIntegration extends Integration
                 $span->resource = !$ex && isset($args[0]) ? $args[0] : $span->name;
                 $span->service = $service;
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
 
                 $this->load->helper('url');
                 $rootSpan->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize(base_url(uri_string()))
@@ -113,6 +116,7 @@ class CodeIgniterIntegration extends Integration
                 $span->service = $service;
                 $span->resource = !$ex && isset($args[0]) ? $args[0] : $span->name;
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
             }
         );
 
@@ -128,6 +132,7 @@ class CodeIgniterIntegration extends Integration
                 $span->name = "{$class}.query";
                 $span->service = $service;
                 $span->type = Type::SQL;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
                 $span->resource = !$ex && isset($args[0]) ? $args[0] : $span->name;
             }
         );
@@ -170,6 +175,7 @@ class CodeIgniterIntegration extends Integration
                 $span->name = "{$class}.get";
                 $span->service = $service;
                 $span->type = Type::CACHE;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
                 $span->resource = !$ex && isset($args[0]) ? $args[0] : $span->name;
             }
         );
@@ -182,6 +188,7 @@ class CodeIgniterIntegration extends Integration
                 $span->name = "{$class}.save";
                 $span->service = $service;
                 $span->type = Type::CACHE;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
                 $span->resource = !$ex && isset($args[0]) ? $args[0] : $span->name;
             }
         );
@@ -194,6 +201,7 @@ class CodeIgniterIntegration extends Integration
                 $span->name = "{$class}.delete";
                 $span->service = $service;
                 $span->type = Type::CACHE;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
                 $span->resource = !$ex && isset($args[0]) ? $args[0] : $span->name;
             }
         );
@@ -206,6 +214,7 @@ class CodeIgniterIntegration extends Integration
                 $span->name = "{$class}.clean";
                 $span->service = $service;
                 $span->type = Type::CACHE;
+                $span->meta[Tag::COMPONENT] = 'codeigniter';
                 $span->resource = $span->name;
             }
         );

--- a/src/Integrations/Integrations/Curl/CurlIntegration.php
+++ b/src/Integrations/Integrations/Curl/CurlIntegration.php
@@ -49,6 +49,7 @@ final class CurlIntegration extends Integration
             'posthook' => function (SpanData $span, $args, $retval) use ($integration) {
                 $span->name = $span->resource = 'curl_exec';
                 $span->type = Type::HTTP_CLIENT;
+                $span->meta[Tag::COMPONENT] = 'curl';
                 $span->service = 'curl';
                 $integration->addTraceAnalyticsIfEnabled($span);
 

--- a/src/Integrations/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
+++ b/src/Integrations/Integrations/ElasticSearch/V1/ElasticSearchIntegration.php
@@ -43,6 +43,7 @@ class ElasticSearchIntegration extends Integration
                 $span->name = "Elasticsearch.Client.__construct";
                 $span->service = ElasticSearchIntegration::NAME;
                 $span->type = Type::ELASTICSEARCH;
+                $span->meta[Tag::COMPONENT] = 'elasticsearch';
                 $span->resource = "__construct";
             }
         ]);
@@ -105,6 +106,7 @@ class ElasticSearchIntegration extends Integration
             $span->resource = 'performRequest';
             $span->service = ElasticSearchIntegration::NAME;
             $span->type = Type::ELASTICSEARCH;
+            $span->meta[Tag::COMPONENT] = 'elasticsearch';
 
             try {
                 $span->meta[Tag::ELASTICSEARCH_URL] = $this->getURI();
@@ -123,6 +125,7 @@ class ElasticSearchIntegration extends Integration
             $span->resource = 'performRequest';
             $span->service = ElasticSearchIntegration::NAME;
             $span->type = Type::ELASTICSEARCH;
+            $span->meta[Tag::COMPONENT] = 'elasticsearch';
 
             $span->meta[Tag::ELASTICSEARCH_URL] = $args[1];
             $span->meta[Tag::ELASTICSEARCH_METHOD] = $args[0];
@@ -165,6 +168,7 @@ class ElasticSearchIntegration extends Integration
 
                     $span->service = ElasticSearchIntegration::NAME;
                     $span->type = Type::ELASTICSEARCH;
+                    $span->meta[Tag::COMPONENT] = 'elasticsearch';
                     $span->resource = ElasticSearchCommon::buildResourceName($name, isset($args[0]) ? $args[0] : []);
                 }
             ]
@@ -183,6 +187,7 @@ class ElasticSearchIntegration extends Integration
             $span->resource = $operationName;
             $span->service = ElasticSearchIntegration::NAME;
             $span->type = Type::ELASTICSEARCH;
+            $span->meta[Tag::COMPONENT] = 'elasticsearch';
         });
     }
 
@@ -204,6 +209,7 @@ class ElasticSearchIntegration extends Integration
             $span->resource = ElasticSearchCommon::buildResourceName($name, $params);
             $span->service = ElasticSearchIntegration::NAME;
             $span->type = Type::ELASTICSEARCH;
+            $span->meta[Tag::COMPONENT] = 'elasticsearch';
         });
     }
 }

--- a/src/Integrations/Integrations/Eloquent/EloquentIntegration.php
+++ b/src/Integrations/Integrations/Eloquent/EloquentIntegration.php
@@ -105,6 +105,7 @@ class EloquentIntegration extends Integration
     {
         $span->type = Type::SQL;
         $span->service = $this->getAppName();
+        $span->meta[Tag::COMPONENT] = 'eloquent';
     }
 
     /**

--- a/src/Integrations/Integrations/Guzzle/GuzzleIntegration.php
+++ b/src/Integrations/Integrations/Guzzle/GuzzleIntegration.php
@@ -43,6 +43,7 @@ class GuzzleIntegration extends Integration
                 $span->name = 'GuzzleHttp\Client.send';
                 $span->service = 'guzzle';
                 $span->type = Type::HTTP_CLIENT;
+                $span->meta[Tag::COMPONENT] = 'guzzle';
 
                 if (isset($args[0])) {
                     $integration->addRequestInfo($span, $args[0]);
@@ -74,6 +75,7 @@ class GuzzleIntegration extends Integration
                 $span->name = 'GuzzleHttp\Client.transfer';
                 $span->service = 'guzzle';
                 $span->type = Type::HTTP_CLIENT;
+                $span->meta[Tag::COMPONENT] = 'guzzle';
 
                 if (isset($args[0])) {
                     $integration->addRequestInfo($span, $args[0]);

--- a/src/Integrations/Integrations/Laravel/LaravelIntegration.php
+++ b/src/Integrations/Integrations/Laravel/LaravelIntegration.php
@@ -65,9 +65,11 @@ class LaravelIntegration extends Integration
                     $rootSpan->meta[Tag::HTTP_STATUS_CODE] = $response->getStatusCode();
                 }
                 $rootSpan->service = $integration->getServiceName();
+                $rootSpan->meta[Tag::COMPONENT] = 'laravel';
 
                 $span->name = 'laravel.application.handle';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'laravel';
                 $span->service = $integration->getServiceName();
                 $span->resource = 'Illuminate\Foundation\Application@handle';
             }
@@ -90,6 +92,7 @@ class LaravelIntegration extends Integration
                 $routeName = LaravelIntegration::normalizeRouteName($route->getName());
 
                 $rootSpan->resource = $route->getActionName() . ' ' . $routeName;
+                $rootSpan->meta[Tag::COMPONENT] = 'laravel';
 
                 $rootSpan->meta['laravel.route.name'] = $routeName;
                 $rootSpan->meta['laravel.route.action'] = $route->getActionName();
@@ -107,6 +110,7 @@ class LaravelIntegration extends Integration
             function (SpanData $span) use ($integration) {
                 $span->name = 'laravel.action';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'laravel';
                 $span->service = $integration->getServiceName();
                 $span->resource = $this->uri;
             }
@@ -128,6 +132,7 @@ class LaravelIntegration extends Integration
             function (SpanData $span, $args) use ($integration) {
                 $span->name = 'laravel.event.handle';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'laravel';
                 $span->service = $integration->getServiceName();
                 $span->resource = $args[0];
             }
@@ -136,6 +141,7 @@ class LaravelIntegration extends Integration
         \DDTrace\trace_method('Illuminate\View\View', 'render', function (SpanData $span) use ($integration) {
             $span->name = 'laravel.view.render';
             $span->type = Type::WEB_SERVLET;
+            $span->meta[Tag::COMPONENT] = 'laravel';
             $span->service = $integration->getServiceName();
             $span->resource = $this->view;
         });
@@ -148,6 +154,7 @@ class LaravelIntegration extends Integration
                 // users would see a span changing name as they upgrade to the new version.
                 $span->name = $integration->isLumen($rootSpan) ? 'lumen.view' : 'laravel.view';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'laravel';
                 $span->service = $integration->getServiceName();
                 if (isset($args[0]) && \is_string($args[0])) {
                     $span->resource = $args[0];
@@ -162,6 +169,7 @@ class LaravelIntegration extends Integration
                 $serviceName = $integration->getServiceName();
                 $span->name = 'laravel.provider.load';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'laravel';
                 $span->service = $serviceName;
                 $span->resource = 'Illuminate\Foundation\ProviderRepository::load';
                 $rootSpan->name = 'laravel.request';
@@ -175,6 +183,7 @@ class LaravelIntegration extends Integration
             function () use ($rootSpan, $integration) {
                 $rootSpan->name = 'laravel.artisan';
                 $rootSpan->resource = !empty($_SERVER['argv'][1]) ? 'artisan ' . $_SERVER['argv'][1] : 'artisan';
+                $rootSpan->meta[Tag::COMPONENT] = 'laravel';
             }
         );
 

--- a/src/Integrations/Integrations/Lumen/LumenIntegration.php
+++ b/src/Integrations/Integrations/Lumen/LumenIntegration.php
@@ -54,6 +54,7 @@ class LumenIntegration extends Integration
                 $request = $args[0];
                 $rootSpan->name = 'lumen.request';
                 $rootSpan->service = $appName;
+                $rootSpan->meta[Tag::COMPONENT] = 'lumen';
                 $integration->addTraceAnalyticsIfEnabled($rootSpan);
 
                 if (!array_key_exists(Tag::HTTP_URL, $rootSpan->meta)) {
@@ -74,6 +75,7 @@ class LumenIntegration extends Integration
                 $hook => function (SpanData $span, $args) use ($rootSpan, $appName) {
                     $span->service = $appName;
                     $span->type = 'web';
+                    $span->meta[Tag::COMPONENT] = 'lumen';
                     if (count($args) < 1 || !\is_array($args[0])) {
                         return;
                     }
@@ -103,6 +105,7 @@ class LumenIntegration extends Integration
         $exceptionRender = function (SpanData $span, $args) use ($rootSpan, $appName, $integration) {
             $span->service = $appName;
             $span->type = 'web';
+            $span->meta[Tag::COMPONENT] = 'lumen';
             if (count($args) < 1 || !\is_a($args[0], 'Throwable')) {
                 return;
             }

--- a/src/Integrations/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/Integrations/Integrations/Memcached/MemcachedIntegration.php
@@ -180,6 +180,7 @@ class MemcachedIntegration extends Integration
     {
         $span->name = "Memcached.$command";
         $span->type = Type::MEMCACHED;
+        $span->meta[Tag::COMPONENT] = 'memcached';
         $span->service = 'memcached';
         $span->resource = $command;
         $span->meta['memcached.command'] = $command;

--- a/src/Integrations/Integrations/MongoDB/MongoDBIntegration.php
+++ b/src/Integrations/Integrations/MongoDB/MongoDBIntegration.php
@@ -632,6 +632,7 @@ class MongoDBIntegration extends Integration
         $span->name = $name;
         $span->service = 'mongodb';
         $span->type = Type::MONGO;
+        $span->meta[Tag::COMPONENT] = 'mongodb';
         $span->meta[Tag::SPAN_KIND] = 'client';
         $serializedQuery = $rawQuery ? MongoDBIntegration::serializeQuery($rawQuery) : null;
         $span->resource = \implode(' ', array_filter([$method, $database, $collection, $command, $serializedQuery]));

--- a/src/Integrations/Integrations/Nette/NetteIntegration.php
+++ b/src/Integrations/Integrations/Nette/NetteIntegration.php
@@ -66,6 +66,7 @@ class NetteIntegration extends Integration
             function (SpanData $span) use ($service) {
                 $span->name = 'nette.configurator.createRobotLoader';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'nette';
                 $span->service = $service;
             }
         );
@@ -76,6 +77,7 @@ class NetteIntegration extends Integration
             function (SpanData $span) use ($rootSpan, $service) {
                 $span->name = 'nette.application.run';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'nette';
                 $span->service = $service;
                 $rootSpan->meta[Tag::HTTP_STATUS_CODE] = http_response_code();
             }
@@ -88,6 +90,7 @@ class NetteIntegration extends Integration
 
                 $span->name = 'nette.presenter.run';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'nette';
                 $span->service = $service;
 
                 if (count($args) < 1 || !\is_a($args[0], '\Nette\Application\Request')) {
@@ -111,6 +114,7 @@ class NetteIntegration extends Integration
             function (SpanData $span, $args) use ($service) {
                 $span->name = 'nette.latte.createTemplate';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'nette';
                 $span->service = $service;
 
                 if (count($args) >= 1) {
@@ -125,6 +129,7 @@ class NetteIntegration extends Integration
             function (SpanData $span, $args) use ($service) {
                 $span->name = 'nette.latte.render';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'nette';
                 $span->service = $service;
 
                 if (count($args) >= 1) {
@@ -139,6 +144,7 @@ class NetteIntegration extends Integration
             function (SpanData $span, $args) use ($service) {
                 $span->name = 'nette.latte.render';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'nette';
                 $span->service = $service;
 
                 if (count($args) >= 1) {

--- a/src/Integrations/Integrations/PDO/PDOIntegration.php
+++ b/src/Integrations/Integrations/PDO/PDOIntegration.php
@@ -194,6 +194,7 @@ class PDOIntegration extends Integration
         }
 
         $span->type = Type::SQL;
+        $span->meta[Tag::COMPONENT] = 'PDO';
         $span->service = 'pdo';
         if (\DDTrace\Util\Runtime::getBoolIni("datadog.trace.db_client_split_by_instance")) {
             if (isset($storedConnectionInfo[Tag::TARGET_HOST])) {

--- a/src/Integrations/Integrations/Slim/SlimIntegration.php
+++ b/src/Integrations/Integrations/Slim/SlimIntegration.php
@@ -48,6 +48,7 @@ class SlimIntegration extends Integration
                 $rootSpan = \DDTrace\root_span();
                 $integration->addTraceAnalyticsIfEnabled($rootSpan);
                 $rootSpan->service = $appName;
+                $rootSpan->meta[Tag::COMPONENT] = 'slim';
 
                 if ('4' === $majorVersion) {
                     \DDTrace\hook_method('Slim\\MiddlewareDispatcher', 'addMiddleware', function ($This, $self, $args) {
@@ -57,6 +58,7 @@ class SlimIntegration extends Integration
                                 $span->name = 'slim.middleware';
                                 $span->resource = \get_class($this);
                                 $span->type = Type::WEB_SERVLET;
+                                $span->meta[Tag::COMPONENT] = 'slim';
                                 $span->service = \ddtrace_config_app_name(SlimIntegration::NAME);
                             };
                             \DDTrace\trace_method($name, 'process', $closure);
@@ -104,6 +106,7 @@ class SlimIntegration extends Integration
 
                     $span->resource = $callableName ?: 'controller';
                     $span->type = Type::WEB_SERVLET;
+                    $span->meta[Tag::COMPONENT] = 'slim';
                     $span->service = $appName;
 
                     /** @var ServerRequestInterface $request */
@@ -146,6 +149,7 @@ class SlimIntegration extends Integration
                     $span->name = 'slim.view';
                     $span->service = $appName;
                     $span->type = Type::WEB_SERVLET;
+                    $span->meta[Tag::COMPONENT] = 'slim';
                     $template = $args[1];
                     $span->resource = $template;
                     $span->meta['slim.view'] = $template;

--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -62,6 +62,7 @@ class SymfonyIntegration extends Integration
                         $this->appName = \ddtrace_config_app_name('symfony');
                         $rootSpan->name = 'symfony.request';
                         $rootSpan->service = $this->appName;
+                        $rootSpan->meta[Tag::COMPONENT] = 'symfony';
                     }
 
                     $span->name = 'symfony.httpkernel.kernel.boot';

--- a/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/Integrations/Integrations/Symfony/SymfonyIntegration.php
@@ -48,6 +48,7 @@ class SymfonyIntegration extends Integration
                 $span->name = 'symfony.httpkernel.kernel.handle';
                 $span->resource = \get_class($this);
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'symfony';
                 $span->service = \ddtrace_config_app_name('symfony');
             }
         );
@@ -66,6 +67,7 @@ class SymfonyIntegration extends Integration
                     $span->name = 'symfony.httpkernel.kernel.boot';
                     $span->resource = \get_class($this);
                     $span->type = Type::WEB_SERVLET;
+                    $span->meta[Tag::COMPONENT] = 'symfony';
                     $span->service = \ddtrace_config_app_name('symfony');
                 }
             ]
@@ -145,6 +147,7 @@ class SymfonyIntegration extends Integration
                 $span->name = $span->resource = 'symfony.kernel.handle';
                 $span->service = $integration->appName;
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'symfony';
 
                 $integration->symfonyRequestSpan->meta[Tag::HTTP_METHOD] = $request->getMethod();
 
@@ -206,6 +209,7 @@ class SymfonyIntegration extends Integration
                                                 $span->name = 'symfony.controller';
                                                 $span->resource = $controllerName;
                                                 $span->type = Type::WEB_SERVLET;
+                                                $span->meta[Tag::COMPONENT] = 'symfony';
                                                 $span->service = $integration->appName;
                                             }
                                         );
@@ -217,6 +221,7 @@ class SymfonyIntegration extends Integration
                                             $span->name = 'symfony.controller';
                                             $span->resource = $controllerName;
                                             $span->type = Type::WEB_SERVLET;
+                                            $span->meta[Tag::COMPONENT] = 'symfony';
                                             $span->service = $integration->appName;
                                         }
                                     );
@@ -242,6 +247,7 @@ class SymfonyIntegration extends Integration
         // Handling exceptions
         $exceptionHandlingTracer = function (SpanData $span, $args, $retval) use ($integration) {
             $span->name = $span->resource = 'symfony.kernel.handleException';
+            $span->meta[Tag::COMPONENT] = 'symfony';
             $span->service = $integration->appName;
             if (!(isset($retval) && \method_exists($retval, 'getStatusCode') && $retval->getStatusCode() < 500)) {
                 $integration->setError($integration->symfonyRequestSpan, $args[0]);
@@ -257,6 +263,7 @@ class SymfonyIntegration extends Integration
             $span->name = 'symfony.templating.render';
             $span->service = $integration->appName;
             $span->type = Type::WEB_SERVLET;
+            $span->meta[Tag::COMPONENT] = 'symfony';
 
             $resourceName = count($args) > 0 ? get_class($this) . ' ' . $args[0] : get_class($this);
             $span->resource = $resourceName;

--- a/src/Integrations/Integrations/Yii/YiiIntegration.php
+++ b/src/Integrations/Integrations/Yii/YiiIntegration.php
@@ -45,6 +45,7 @@ class YiiIntegration extends Integration
 
         $this->addTraceAnalyticsIfEnabled($rootSpan);
         $service = \ddtrace_config_app_name(YiiIntegration::NAME);
+        $rootSpan->meta[Tag::COMPONENT] = 'yii';
 
         \DDTrace\trace_method(
             'yii\web\Application',
@@ -52,6 +53,7 @@ class YiiIntegration extends Integration
             function (SpanData $span) use ($service) {
                 $span->name = $span->resource = \get_class($this) . '.run';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'yii';
                 $span->service = $service;
             }
         );
@@ -79,6 +81,7 @@ class YiiIntegration extends Integration
             function (SpanData $span, $args) use ($service) {
                 $span->name = \get_class($this) . '.runAction';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'yii';
                 $span->service = $service;
                 $span->resource = YiiIntegration::extractResourceNameFromRunAction($args) ?: $span->name;
             }
@@ -90,6 +93,7 @@ class YiiIntegration extends Integration
             function (SpanData $span, $args) use (&$firstController, $service, $rootSpan) {
                 $span->name = \get_class($this) . '.runAction';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'yii';
                 $span->service = $service;
                 $span->resource = YiiIntegration::extractResourceNameFromRunAction($args) ?: $span->name;
 
@@ -141,6 +145,7 @@ class YiiIntegration extends Integration
             function (SpanData $span, $args) use ($service) {
                 $span->name = \get_class($this) . '.renderFile';
                 $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = 'yii';
                 $span->service = $service;
                 $span->resource = isset($args[0]) && \is_string($args[0]) ? $args[0] : $span->name;
             }

--- a/src/Integrations/Integrations/ZendFramework/V1/TraceRequest.php
+++ b/src/Integrations/Integrations/ZendFramework/V1/TraceRequest.php
@@ -31,6 +31,7 @@ class TraceRequest extends Zend_Controller_Plugin_Abstract
         $span->meta['zf1.route_name'] = $route;
         $span->resource = $controller . '@' . $action . ' ' . $route;
         $span->meta[Tag::HTTP_METHOD] = $request->getMethod();
+        $span->meta[Tag::COMPONENT] = 'zendframework';
 
         if (!array_key_exists(Tag::HTTP_URL, $span->meta)) {
             $span->meta[Tag::HTTP_URL] = \DDTrace\Util\Normalizer::urlSanitize(

--- a/src/Integrations/Integrations/ZendFramework/ZendFrameworkIntegration.php
+++ b/src/Integrations/Integrations/ZendFramework/ZendFrameworkIntegration.php
@@ -77,6 +77,7 @@ class ZendFrameworkIntegration extends Integration
                     $rootSpan->meta['zf1.action'] = $action;
                     $rootSpan->meta['zf1.route_name'] = $route;
                     $rootSpan->resource = $controller . '@' . $action . ' ' . $route;
+                    $rootSpan->meta[Tag::COMPONENT] = 'zendframework';
                     $rootSpan->meta[Tag::HTTP_METHOD] = $request->getMethod();
 
                     if (!array_key_exists(Tag::HTTP_URL, $rootSpan->meta)) {

--- a/src/api/Tag.php
+++ b/src/api/Tag.php
@@ -13,6 +13,8 @@ class Tag
     const MANUAL_DROP = 'manual.drop';
     const PID = 'system.pid';
     const RESOURCE_NAME = 'resource.name';
+    // SIGNALFX: component tag is for SFX zipkin, cannot reliably deduce in serializer, thus set explicitly
+    const COMPONENT = 'component';
     const DB_STATEMENT = 'sql.query';
     const ERROR = 'error';
     const ERROR_MSG = 'error.msg'; // string representing the error message

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -372,6 +372,10 @@ final class SpanChecker
             if (!isset($expectedTags['_dd.p.dm'])) {
                 unset($filtered['_dd.p.dm']);
             }
+            // SIGNALFX: Ignore component unless explicitly tested, to avoid failures when new tests are merged in
+            if (!isset($expectedTags['component'])) {
+                unset($filtered['component']);
+            }
             // http.client_ip is present depending on target SAPI and not helpful here to test
             if (!isset($expectedTags['http.client_ip'])) {
                 unset($filtered['http.client_ip']);

--- a/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/CakePHP/V2_8/CommonScenariosTest.php
@@ -29,7 +29,9 @@ class CommonScenariosTest extends CLITestCase
                 'cake_console_test_app',
                 'cli',
                 'cake_console'
-            )
+            )->withExactTags([
+                'component' => 'cakephp',
+            ])
         ]);
     }
 
@@ -43,7 +45,9 @@ class CommonScenariosTest extends CLITestCase
                 'cake_console_test_app',
                 'cli',
                 'cake_console command_list'
-            )
+            )->withExactTags([
+                'component' => 'cakephp',
+            ])
         ]);
     }
 

--- a/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Custom/Autoloaded/CommonScenariosTest.php
@@ -30,6 +30,7 @@ final class CommonScenariosTest extends CLITestCase
                 'cli',
                 'run'
             )->withExactTags([
+                'component' => 'web.request',
             ])
         ]);
     }

--- a/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V5_8/CommonScenariosTest.php
@@ -30,6 +30,7 @@ class CommonScenariosTest extends CLITestCase
                 'cli',
                 'artisan'
             )->withExactTags([
+                'component' => 'laravel',
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -50,6 +51,7 @@ class CommonScenariosTest extends CLITestCase
                 'cli',
                 'artisan route:list'
             )->withExactTags([
+                'component' => 'laravel',
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -70,6 +72,7 @@ class CommonScenariosTest extends CLITestCase
                 'cli',
                 'artisan foo:error'
             )->withExactTags([
+                'component' => 'laravel',
             ])->withExistingTagsNames([
                 'error.msg',
                 'error.stack'

--- a/tests/Integrations/CLI/Laravel/V8_X/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Laravel/V8_X/CommonScenariosTest.php
@@ -30,6 +30,7 @@ class CommonScenariosTest extends CLITestCase
                 'cli',
                 'artisan'
             )->withExactTags([
+                'component' => 'laravel',
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -50,6 +51,7 @@ class CommonScenariosTest extends CLITestCase
                 'cli',
                 'artisan route:list'
             )->withExactTags([
+                'component' => 'laravel',
             ])->withChildren([
                 SpanAssertion::exists(
                     'laravel.provider.load',
@@ -70,6 +72,7 @@ class CommonScenariosTest extends CLITestCase
                 'cli',
                 'artisan foo:error'
             )->withExactTags([
+                'component' => 'laravel',
             ])->withExistingTagsNames([
                 'error.msg',
                 'error.stack'

--- a/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
+++ b/tests/Integrations/CakePHP/V2_8/CommonScenariosTest.php
@@ -51,6 +51,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'cakephp',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Controller.invokeAction',
@@ -72,6 +73,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'cakephp',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Controller.invokeAction',
@@ -86,6 +88,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'SimpleView/index.ctp'
                         )->withExactTags([
                             'cakephp.view' => 'SimpleView/index.ctp',
+                            'component' => 'cakephp',
                         ]),
                     ]),
                 ],
@@ -101,6 +104,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'cakephp',
                     ])->withExistingTagsNames([
                         'error.stack'
                     ])->setError(
@@ -122,6 +126,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'Errors/index.ctp'
                         )->withExactTags([
                             'cakephp.view' => 'Errors/index.ctp',
+                            'component' => 'cakephp',
                         ]),
                     ]),
                 ],

--- a/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/CommonScenariosTest.php
@@ -52,6 +52,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_URL => 'http://localhost:9999/simple?key=value&<redacted>',
                         Tag::HTTP_STATUS_CODE => '200',
                         'app.endpoint' => 'Simple::index',
+                        'component' => 'codeigniter',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Simple.index',
@@ -72,6 +73,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_URL => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         Tag::HTTP_STATUS_CODE => '200',
                         'app.endpoint' => 'Simple_View::index',
+                        'component' => 'codeigniter',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Simple_View.index',
@@ -100,6 +102,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         // CodeIgniter's error handler does not adjust the status code
                         Tag::HTTP_STATUS_CODE => '200',
                         'app.endpoint' => 'Error_::index',
+                        'component' => 'codeigniter',
                     ])
                     ->setError("Exception", "Uncaught Exception: datadog in %s:%d")
                     ->withExistingTagsNames(['error.stack'])

--- a/tests/Integrations/CodeIgniter/V2_2/ExitTest.php
+++ b/tests/Integrations/CodeIgniter/V2_2/ExitTest.php
@@ -41,6 +41,7 @@ class ExitTest extends WebFrameworkTestCase
                     Tag::HTTP_URL => 'http://localhost:9999/exits',
                     Tag::HTTP_STATUS_CODE => '200',
                     'app.endpoint' => 'Exits::index',
+                    'component' => 'codeigniter',
                 ])->withChildren([
                     SpanAssertion::build(
                         'Exits.index',

--- a/tests/Integrations/Curl/CurlIntegrationTest.php
+++ b/tests/Integrations/Curl/CurlIntegrationTest.php
@@ -86,6 +86,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -107,6 +108,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -130,6 +132,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -153,6 +156,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://?:?@httpbin_integration/basic-auth/my_user/my_password',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -177,6 +181,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/basic-auth/my_user/my_password',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -205,6 +210,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                         ->withExactTags([
                             'http.url' => self::URL . '/status/200',
                             'http.status_code' => '200',
+                            'component' => 'curl',
                         ])
                         ->withExistingTagsNames(self::commonCurlInfoTags())
                         ->skipTagsLike('/^curl\..*/'),
@@ -226,6 +232,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -248,6 +255,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/404',
                     'http.status_code' => '404',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -270,6 +278,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://10.255.255.1/',
                     'http.status_code' => '0',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(['error.msg'])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
@@ -294,6 +303,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://10.255.255.1/',
                     'http.status_code' => '0',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(['error.msg'])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
@@ -318,6 +328,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://__i_am_not_real__.invalid/',
                     'http.status_code' => '0',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/')
@@ -454,6 +465,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => self::URL . '/status/200',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -483,6 +495,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                 ->withExactTags([
                     'http.url' => 'http://?:?@httpbin_integration/status/200',
                     'http.status_code' => '200',
+                    'component' => 'curl',
                 ])
                 ->withExistingTagsNames(self::commonCurlInfoTags())
                 ->skipTagsLike('/^curl\..*/'),
@@ -538,6 +551,7 @@ final class CurlIntegrationTest extends IntegrationTestCase
                         ->withExactTags([
                             'http.url' => self::URL . '/status/200',
                             'http.status_code' => '200',
+                            'component' => 'curl',
                         ])
                         ->withExistingTagsNames(self::commonCurlInfoTags())
                         ->skipTagsLike('/^curl\..*/'),

--- a/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CircuitBreakerTest.php
@@ -54,6 +54,7 @@ final class CircuitBreakerTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/circuit_breaker',
                     'http.status_code' => '200',
+                    'component' => 'web.request',
                 ]),
             ]
         );

--- a/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CommonScenariosTest.php
@@ -49,6 +49,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'web.request',
                     ]),
                 ],
                 'A simple GET request with a view' => [
@@ -61,6 +62,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'web.request',
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -73,6 +75,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'web.request',
                     ])->setError(),
                 ],
             ]

--- a/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
+++ b/tests/Integrations/Custom/Autoloaded/FatalErrorTest.php
@@ -42,6 +42,7 @@ final class FatalErrorTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/fatal',
                     'http.status_code' => '200',
+                    'component' => 'web.request',
                 ])
                 ->setError("E_ERROR", "Intentional E_ERROR")
                 ->withExistingTagsNames(['error.stack']),

--- a/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
+++ b/tests/Integrations/Custom/Autoloaded/TraceSearchConfigTest.php
@@ -42,6 +42,7 @@ final class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/simple',
                     'http.status_code' => '200',
+                    'component' => 'web.request',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersConfiguredTest.php
@@ -43,6 +43,7 @@ final class HttpHeadersConfiguredTest extends WebFrameworkTestCase
             'http.request.headers.first-header' => 'some value: with colon',
             'http.request.headers.forth-header' => '123',
             'http.response.headers.third-header' => 'separated: with  : colon',
+            'component' => 'web.request',
         ];
         if (\getenv('DD_TRACE_TEST_SAPI') != 'apache2handler') {
             $tags['http.request.headers.w__rd-header'] = 'foo';

--- a/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/HttpHeadersNotConfiguredTest.php
@@ -46,6 +46,7 @@ final class HttpHeadersNotConfiguredTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/',
                     'http.status_code' => 200,
+                    'component' => 'web.request',
                 ]),
             ]
         );

--- a/tests/Integrations/Custom/NotAutoloaded/IncomingUserInfoTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/IncomingUserInfoTest.php
@@ -37,6 +37,7 @@ final class IncomingUserInfoTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:' . self::PORT . '/',
                     'http.status_code' => 200,
+                    'component' => 'web.request',
                 ]),
             ]
         );

--- a/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V5/GuzzleIntegrationTest.php
@@ -314,6 +314,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ]),
         ]);
     }
@@ -332,6 +333,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://?:?@example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ]),
         ]);
     }
@@ -359,6 +361,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                             'http.method' => 'GET',
                             'http.url' => self::URL . '/status/200',
                             'http.status_code' => '200',
+                            'component' => 'guzzle',
                         ])
                         ->withChildren([
                             SpanAssertion::exists('curl_exec'),

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -88,6 +88,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'PUT',
                     'http.url' => 'http://example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ])
                 ->withChildren([
                     SpanAssertion::build('GuzzleHttp\Client.transfer', 'guzzle', 'http', 'transfer')
@@ -96,6 +97,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                             'http.method' => 'PUT',
                             'http.url' => 'http://example.com',
                             'http.status_code' => '200',
+                            'component' => 'guzzle',
                         ]),
                 ])
         ]);
@@ -113,6 +115,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ]),
         ]);
     }
@@ -130,6 +133,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://?:?@example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ]),
         ]);
     }
@@ -277,6 +281,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ]),
         ]);
     }
@@ -326,6 +331,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ]),
         ]);
     }
@@ -344,6 +350,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://?:?@example.com',
                     'http.status_code' => '200',
+                    'component' => 'guzzle',
                 ]),
         ]);
     }
@@ -371,6 +378,7 @@ class GuzzleIntegrationTest extends IntegrationTestCase
                             'http.method' => 'GET',
                             'http.url' => self::URL . '/status/200',
                             'http.status_code' => '200',
+                            'component' => 'guzzle',
                         ])
                         ->withChildren([
                             SpanAssertion::exists('GuzzleHttp\Client.transfer')

--- a/tests/Integrations/Laravel/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V4/CommonScenariosTest.php
@@ -50,6 +50,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '200',
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
+                            'component' => 'laravel',
                         ])
                         ->withChildren([
                             SpanAssertion::exists('laravel.application.handle')
@@ -58,6 +59,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         ->withExactTags([
                                             'some.key1' => 'value',
                                             'some.key2' => 'value2',
+                                            'component' => 'laravel',
                                         ]),
                                     SpanAssertion::exists('laravel.event.handle'),
                                     SpanAssertion::exists('laravel.event.handle'),
@@ -98,6 +100,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         ->withExactTags([
                                             'some.key1' => 'value',
                                             'some.key2' => 'value2',
+                                            'component' => 'laravel',
                                         ])
                                         ->withChildren([
                                             SpanAssertion::exists('laravel.event.handle'),
@@ -130,6 +133,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'http.status_code' => '500',
                             'some.key1' => 'value',
                             'some.key2' => 'value2',
+                            'component' => 'laravel',
                         ])->setError()->withChildren([
                             SpanAssertion::exists('laravel.application.handle')
                                 ->withChildren([

--- a/tests/Integrations/Laravel/V4/EloquentTest.php
+++ b/tests/Integrations/Laravel/V4/EloquentTest.php
@@ -34,7 +34,9 @@ class EloquentTest extends WebFrameworkTestCase
             'laravel',
             'sql',
             'User'
-        )->withExactTags([]));
+        )->withExactTags([
+            'component' => 'eloquent',
+        ]));
     }
 
     public function testGet()
@@ -50,6 +52,7 @@ class EloquentTest extends WebFrameworkTestCase
             'select * from `users`'
         )->withExactTags([
             'sql.query' => 'select * from `users`',
+            'component' => 'eloquent',
         ]));
     }
 
@@ -65,6 +68,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -81,6 +85,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -97,6 +102,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 

--- a/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V4/TraceSearchConfigTest.php
@@ -40,6 +40,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,

--- a/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_7/CommonScenariosTest.php
@@ -51,9 +51,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple')
                             ->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         SpanAssertion::exists(
                             'laravel.provider.load',
@@ -73,9 +75,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                             ->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         SpanAssertion::exists(
                             'laravel.provider.load',
@@ -87,6 +91,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'web',
                             'simple_view'
                         )->withExactTags([
+                            'component' => 'laravel',
                         ])->withChildren([
                             SpanAssertion::build(
                                 'laravel.view',
@@ -94,6 +99,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 'web',
                                 '*/resources/views/simple_view.blade.php'
                             )->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         ]),
                     ]),
@@ -110,6 +116,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'laravel',
                     ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
                         SpanAssertion::exists(

--- a/tests/Integrations/Laravel/V5_7/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_7/EloquentTest.php
@@ -34,7 +34,9 @@ class EloquentTest extends WebFrameworkTestCase
             'Laravel',
             'sql',
             'App\User'
-        )->withExactTags([]));
+        )->withExactTags([
+            'component' => 'eloquent',
+        ]));
     }
 
     public function testRefresh()
@@ -50,6 +52,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -66,6 +69,7 @@ class EloquentTest extends WebFrameworkTestCase
             'select * from `users`'
         )->withExactTags([
             'sql.query' => 'select * from `users`',
+            'component' => 'eloquent',
         ]));
     }
 
@@ -81,6 +85,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -97,6 +102,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -113,6 +119,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 

--- a/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_7/TraceSearchConfigTest.php
@@ -45,6 +45,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,

--- a/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V5_8/CommonScenariosTest.php
@@ -51,9 +51,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple')
                             ->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         SpanAssertion::exists(
                             'laravel.provider.load',
@@ -73,9 +75,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                             ->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         SpanAssertion::exists(
                             'laravel.provider.load',
@@ -87,6 +91,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'web',
                             'simple_view'
                         )->withExactTags([
+                            'component' => 'laravel',
                         ])->withChildren([
                             SpanAssertion::build(
                                 'laravel.view',
@@ -94,6 +99,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 'web',
                                 '*/resources/views/simple_view.blade.php'
                             )->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         ]),
                     ]),
@@ -110,6 +116,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'laravel',
                     ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
 

--- a/tests/Integrations/Laravel/V5_8/EloquentTest.php
+++ b/tests/Integrations/Laravel/V5_8/EloquentTest.php
@@ -37,6 +37,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -53,6 +54,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -69,6 +71,7 @@ class EloquentTest extends WebFrameworkTestCase
             'select * from `users`'
         )->withExactTags([
             'sql.query' => 'select * from `users`',
+            'component' => 'eloquent',
         ]));
     }
 
@@ -84,6 +87,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -100,6 +104,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -116,6 +121,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 

--- a/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V5_8/TraceSearchConfigTest.php
@@ -45,6 +45,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,

--- a/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/V8_x/CommonScenariosTest.php
@@ -51,9 +51,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple')
                             ->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         SpanAssertion::exists(
                             'laravel.provider.load',
@@ -73,9 +75,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])->withChildren([
                         SpanAssertion::build('laravel.action', 'laravel_test_app', 'web', 'simple_view')
                             ->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         SpanAssertion::exists(
                             'laravel.provider.load',
@@ -87,6 +91,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'web',
                             'simple_view'
                         )->withExactTags([
+                            'component' => 'laravel',
                         ])->withChildren([
                             SpanAssertion::build(
                                 'laravel.view',
@@ -94,6 +99,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 'web',
                                 '*/resources/views/simple_view.blade.php'
                             )->withExactTags([
+                                'component' => 'laravel',
                             ]),
                         ]),
                     ]),
@@ -110,6 +116,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'laravel',
                     ])->setError('Exception', 'Controller error', true)->withChildren([
                         SpanAssertion::exists('laravel.action'),
 

--- a/tests/Integrations/Laravel/V8_x/EloquentTest.php
+++ b/tests/Integrations/Laravel/V8_x/EloquentTest.php
@@ -37,6 +37,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\\Models\\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -53,6 +54,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\\Models\\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -69,6 +71,7 @@ class EloquentTest extends WebFrameworkTestCase
             'select * from `users`'
         )->withExactTags([
             'sql.query' => 'select * from `users`',
+            'component' => 'eloquent',
         ]));
     }
 
@@ -84,6 +87,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\\Models\\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -100,6 +104,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\\Models\\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 
@@ -116,6 +121,7 @@ class EloquentTest extends WebFrameworkTestCase
             'sql',
             'App\\Models\\User'
         )->withExactTags([
+            'component' => 'eloquent',
         ]));
     }
 

--- a/tests/Integrations/Laravel/V8_x/InternalExceptionsTest.php
+++ b/tests/Integrations/Laravel/V8_x/InternalExceptionsTest.php
@@ -47,6 +47,7 @@ class InternalExceptionsTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/not-implemented',
                         'http.status_code' => '501',
+                        'component' => 'laravel',
                     ])
                     ->withExactMetrics([
                         '_sampling_priority_v1' => 1,
@@ -91,6 +92,7 @@ class InternalExceptionsTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/unauthorized',
                         'http.status_code' => '403',
+                        'component' => 'laravel',
                     ])
                     ->withExactMetrics([
                         '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
+++ b/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
@@ -41,6 +41,7 @@ class RouteCachingTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/unnamed-route',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action'),
@@ -72,6 +73,7 @@ class RouteCachingTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/unnamed-route',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])
                     ->withChildren([
                         SpanAssertion::exists('laravel.action'),

--- a/tests/Integrations/Laravel/V8_x/TraceSearchConfigTest.php
+++ b/tests/Integrations/Laravel/V8_x/TraceSearchConfigTest.php
@@ -45,6 +45,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'laravel',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,

--- a/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_2/CommonScenariosTest.php
@@ -51,6 +51,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'lumen',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',
@@ -59,6 +60,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'Laravel\Lumen\Application.handleFoundRoute'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simpleView',
+                            'component' => 'lumen',
                         ])
                         ->withChildren([
                             SpanAssertion::build(
@@ -66,27 +68,35 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                 'lumen_test_app',
                                 'web',
                                 'simple_view'
-                            )->withExactTags([])
+                            )->withExactTags([
+                                'component' => 'lumen',
+                            ])
                             ->withChildren([
                                 SpanAssertion::build(
                                     'lumen.view',
                                     'lumen_test_app',
                                     'web',
                                     '*/resources/views/simple_view.blade.php'
-                                )->withExactTags([]),
+                                )->withExactTags([
+                                    'component' => 'lumen',
+                                ]),
                                 SpanAssertion::build(
                                     'laravel.event.handle',
                                     'lumen_test_app',
                                     'web',
                                     'composing: simple_view'
-                                )->withExactTags([]),
+                                )->withExactTags([
+                                    'component' => 'lumen',
+                                ]),
                             ]),
                             SpanAssertion::build(
                                 'laravel.event.handle',
                                 'lumen_test_app',
                                 'web',
                                 'creating: simple_view'
-                            )->withExactTags([])
+                            )->withExactTags([
+                                'component' => 'lumen',
+                            ])
                         ])
                     ]),
                 ],
@@ -101,6 +111,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'lumen',
                     ])->withExistingTagsNames(\PHP_MAJOR_VERSION === 5 ? [] : ['error.stack'])
                     ->setError(
                         'Exception',
@@ -114,6 +125,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'Laravel\Lumen\Application.handleFoundRoute'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
+                            'component' => 'lumen',
                         ])
                         ->withExistingTagsNames([
                             'error.stack'
@@ -144,6 +156,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                 'http.status_code' => '200',
+                'component' => 'lumen',
             ])->withChildren([
                 SpanAssertion::build(
                     'Laravel\Lumen\Application.handleFoundRoute',
@@ -152,6 +165,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     'simple_route'
                 )->withExactTags([
                     'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                    'component' => 'lumen',
                 ]),
             ]),
         ];
@@ -170,6 +184,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                 'http.status_code' => '500',
+                'component' => 'lumen',
             ])->setError()
                 ->withChildren([
                     SpanAssertion::build(
@@ -179,6 +194,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'Laravel\Lumen\Application.handleFoundRoute'
                     )->withExactTags([
                         'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
+                        'component' => 'lumen',
                     ])->withExistingTagsNames([
                         'error.stack'
                     ])->setError('Exception', 'Controller error'),

--- a/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_2/TraceSearchConfigTest.php
@@ -45,6 +45,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'lumen',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
@@ -58,6 +59,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'simple_route'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                            'component' => 'lumen',
                         ]),
                     ])
             ]

--- a/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
+++ b/tests/Integrations/Lumen/V5_6/CommonScenariosTest.php
@@ -51,6 +51,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'lumen',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',
@@ -59,6 +60,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                             'simple_route'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                            'component' => 'lumen',
                         ]),
                     ]),
                 ],
@@ -73,6 +75,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'lumen',
                     ])->withChildren([
                         SpanAssertion::build(
                             'Laravel\Lumen\Application.handleFoundRoute',
@@ -81,19 +84,24 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                             'Laravel\Lumen\Application.handleFoundRoute'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simpleView',
+                            'component' => 'lumen',
                         ])->withChildren([
                             SpanAssertion::build(
                                 'laravel.view.render',
                                 'lumen_test_app',
                                 'web',
                                 'simple_view'
-                            )->withExactTags([])->withChildren([
+                            )->withExactTags([
+                                'component' => 'lumen',
+                            ])->withChildren([
                                 SpanAssertion::build(
                                     'lumen.view',
                                     'lumen_test_app',
                                     'web',
                                     '*/resources/views/simple_view.blade.php'
-                                )->withExactTags([]),
+                                )->withExactTags([
+                                    'component' => 'lumen',
+                                ]),
                             ]),
                         ]),
                     ]),
@@ -109,6 +117,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'lumen',
                     ])->withExistingTagsNames([
                         'error.stack',
                     ])->setError('Exception', 'Controller error')
@@ -120,6 +129,7 @@ class CommonScenariosTest extends V5_2_CommonScenariosTest
                             'Laravel\Lumen\Application.handleFoundRoute'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@error',
+                            'component' => 'lumen',
                         ])->withExistingTagsNames([
                             'error.stack',
                         ])->setError('Exception', 'Controller error'),

--- a/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
+++ b/tests/Integrations/Lumen/V5_6/DeprecatedResourceNameTest.php
@@ -44,6 +44,7 @@ class DeprecatedResourceNameTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'lumen',
                     ])
                     ->withChildren([
                         SpanAssertion::build(
@@ -53,6 +54,7 @@ class DeprecatedResourceNameTest extends WebFrameworkTestCase
                             'simple_route'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                            'component' => 'lumen',
                         ]),
                     ]),
             ]

--- a/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_6/TraceSearchConfigTest.php
@@ -45,6 +45,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'lumen',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
@@ -58,6 +59,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'simple_route'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                            'component' => 'lumen',
                         ]),
                     ]),
             ]

--- a/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
+++ b/tests/Integrations/Lumen/V5_8/TraceSearchConfigTest.php
@@ -45,6 +45,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'lumen',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,
@@ -58,6 +59,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                             'simple_route'
                         )->withExactTags([
                             'lumen.route.action' => 'App\Http\Controllers\ExampleController@simple',
+                            'component' => 'lumen',
                         ]),
                     ]),
             ]

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -178,6 +178,7 @@ final class MemcachedTest extends IntegrationTestCase
                     'memcached.query' => 'deleteByKey ' . Obfuscation::toObfuscatedString('key'),
                     'memcached.command' => 'deleteByKey',
                     'memcached.server_key' => 'my_server',
+                    'component' => 'memcached',
                 ])),
             SpanAssertion::exists('Memcached.getByKey'),
         ]);
@@ -723,6 +724,7 @@ final class MemcachedTest extends IntegrationTestCase
         return [
             'out.host' => self::$host,
             'out.port' => self::$port,
+            'component' => 'memcached',
         ];
     }
 }

--- a/tests/Integrations/MongoDB/MongoDBTest.php
+++ b/tests/Integrations/MongoDB/MongoDBTest.php
@@ -64,6 +64,7 @@ class MongoDBTest extends IntegrationTestCase
                     'span.kind' => 'client',
                     'out.host' => self::HOST,
                     'out.port' => self::PORT,
+                    'component' => 'mongodb',
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
                 ]),
@@ -106,6 +107,7 @@ class MongoDBTest extends IntegrationTestCase
                 'span.kind' => 'client',
                 'out.host' => self::HOST,
                 'out.port' => self::PORT,
+                'component' => 'mongodb',
             ])->withChildren([
                 SpanAssertion::exists('mongodb.driver.cmd')
             ]),
@@ -162,6 +164,7 @@ class MongoDBTest extends IntegrationTestCase
                 'span.kind' => 'client',
                 'out.host' => self::HOST,
                 'out.port' => self::PORT,
+                'component' => 'mongodb',
             ])->withChildren([
                 SpanAssertion::exists('mongodb.driver.cmd')
             ]),
@@ -186,6 +189,7 @@ class MongoDBTest extends IntegrationTestCase
                     'span.kind' => 'client',
                     'out.host' => self::HOST,
                     'out.port' => self::PORT,
+                    'component' => 'mongodb',
                 ])->setError('MongoDB\Exception\InvalidArgumentException')
                 ->withExistingTagsNames(['error.msg', 'error.stack']),
         ]);
@@ -205,6 +209,7 @@ class MongoDBTest extends IntegrationTestCase
                     'span.kind' => 'client',
                     'out.host' => self::HOST,
                     'out.port' => self::PORT,
+                    'component' => 'mongodb',
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
                 ]),
@@ -284,6 +289,7 @@ class MongoDBTest extends IntegrationTestCase
                     'span.kind' => 'client',
                     'out.host' => self::HOST,
                     'out.port' => self::PORT,
+                    'component' => 'mongodb',
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
                 ]),
@@ -374,6 +380,7 @@ class MongoDBTest extends IntegrationTestCase
                     'span.kind' => 'client',
                     'out.host' => self::HOST,
                     'out.port' => self::PORT,
+                    'component' => 'mongodb',
                 ])->withChildren([
                     SpanAssertion::exists('mongodb.driver.cmd')
                 ]),
@@ -478,6 +485,7 @@ class MongoDBTest extends IntegrationTestCase
                     'span.kind' => 'client',
                     'out.host' => self::HOST,
                     'out.port' => self::PORT,
+                    'component' => 'mongodb',
                 ]),
         ];
 
@@ -519,6 +527,7 @@ class MongoDBTest extends IntegrationTestCase
                 'span.kind' => 'client',
                 'out.host' => self::HOST,
                 'out.port' => self::PORT,
+                'component' => 'mongodb',
             ]),
         ];
 
@@ -561,6 +570,7 @@ class MongoDBTest extends IntegrationTestCase
                 'span.kind' => 'client',
                 'out.host' => self::HOST,
                 'out.port' => self::PORT,
+                'component' => 'mongodb',
             ]),
         ];
 
@@ -615,6 +625,7 @@ class MongoDBTest extends IntegrationTestCase
                 'span.kind' => 'client',
                 'out.host' => self::HOST,
                 'out.port' => self::PORT,
+                'component' => 'mongodb',
             ]),
         ];
 
@@ -669,6 +680,7 @@ class MongoDBTest extends IntegrationTestCase
                 'span.kind' => 'client',
                 'out.host' => self::HOST,
                 'out.port' => self::PORT,
+                'component' => 'mongodb',
             ])
         ];
 
@@ -738,6 +750,7 @@ class MongoDBTest extends IntegrationTestCase
                 'mongodb.deletes.1.filter' => '{"brand":"?"}',
                 'mongodb.updates.0.filter' => '{"brand":"?"}',
                 'mongodb.insertsCount' => 2,
+                'component' => 'mongodb',
             ]),
         ]);
     }
@@ -767,6 +780,7 @@ class MongoDBTest extends IntegrationTestCase
                 'span.kind' => 'client',
                 'out.host' => self::HOST,
                 'out.port' => self::PORT,
+                'component' => 'mongodb',
             ])->setError()
                 ->withExistingTagsNames(['error.msg', 'error.stack']),
         ]);

--- a/tests/Integrations/Nette/V2_4/NetteTest.php
+++ b/tests/Integrations/Nette/V2_4/NetteTest.php
@@ -54,7 +54,6 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple?key=value&<redacted>',
                         'http.status_code' => '200',
-                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -89,7 +88,6 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
-                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -136,7 +134,6 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/error?key=value&<redacted>',
                         'http.status_code' => '500',
-                        'component' => 'nette',
                     ])
                     ->setError('Internal Server Error')
                     ->withChildren([

--- a/tests/Integrations/Nette/V2_4/NetteTest.php
+++ b/tests/Integrations/Nette/V2_4/NetteTest.php
@@ -54,6 +54,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -88,6 +89,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -113,7 +115,8 @@ final class NetteTest extends WebFrameworkTestCase
                                 Type::WEB_SERVLET,
                                 'nette.latte.render'
                             )->withExactTags([
-                                'nette.latte.templateName' => '%s'
+                                'nette.latte.templateName' => '%s',
+                                'component' => 'nette',
                             ])->withChildren([
                                 SpanAssertion::exists('nette.latte.createTemplate'), // layout template
                                 SpanAssertion::exists('nette.latte.createTemplate'), // simpleView template
@@ -133,6 +136,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'nette',
                     ])
                     ->setError('Internal Server Error')
                     ->withChildren([

--- a/tests/Integrations/Nette/V3_0/NetteTest.php
+++ b/tests/Integrations/Nette/V3_0/NetteTest.php
@@ -54,6 +54,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -88,6 +89,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -113,7 +115,8 @@ final class NetteTest extends WebFrameworkTestCase
                                 Type::WEB_SERVLET,
                                 'nette.latte.render'
                             )->withExactTags([
-                                'nette.latte.templateName' => '%s'
+                                'nette.latte.templateName' => '%s',
+                                'component' => 'nette',
                             ])->withChildren([
                                 SpanAssertion::exists('nette.latte.createTemplate'), // layout template
                                 SpanAssertion::exists('nette.latte.createTemplate'), // simpleView template
@@ -133,6 +136,7 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'nette',
                     ])
                     ->setError(
                         'Exception',

--- a/tests/Integrations/Nette/V3_0/NetteTest.php
+++ b/tests/Integrations/Nette/V3_0/NetteTest.php
@@ -54,7 +54,6 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple?key=value&<redacted>',
                         'http.status_code' => '200',
-                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -89,7 +88,6 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
-                        'component' => 'nette',
                     ])->withChildren([
                         SpanAssertion::build(
                             'nette.configurator.createRobotLoader',
@@ -136,7 +134,6 @@ final class NetteTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:' . self::PORT . '/error?key=value&<redacted>',
                         'http.status_code' => '500',
-                        'component' => 'nette',
                     ])
                     ->setError(
                         'Exception',

--- a/tests/Integrations/PDO/PDOTest.php
+++ b/tests/Integrations/PDO/PDOTest.php
@@ -570,6 +570,7 @@ final class PDOTest extends IntegrationTestCase
             'out.host' => self::MYSQL_HOST,
             'db.name' => self::MYSQL_DATABASE,
             'db.user' => self::MYSQL_USER,
+            'component' => 'PDO',
         ];
     }
 }

--- a/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V3_12/CommonScenariosTest.php
@@ -52,6 +52,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:' . self::PORT . '/simple',
                             'http.status_code' => '200',
+                            'component' => 'slim',
                         ]),
                     ],
                     'A simple GET request with a view' => [
@@ -64,6 +65,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:' . self::PORT . '/simple_view',
                             'http.status_code' => '200',
+                            'component' => 'slim',
                         ])->withChildren([
                             SpanAssertion::build(
                                 'slim.view',
@@ -72,6 +74,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                                 'simple_view.phtml'
                             )->withExactTags([
                                 'slim.view' => 'simple_view.phtml',
+                                'component' => 'slim',
                             ])
                         ]),
                     ],
@@ -85,6 +88,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:' . self::PORT . '/error',
                             'http.status_code' => '500',
+                            'component' => 'slim',
                         ])->setError(null, null /* On PHP 5.6 slim error messages are not traced on sandboxed */),
                     ],
                 ]
@@ -103,6 +107,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                             'http.status_code' => '200',
+                            'component' => 'slim',
                         ])->withChildren([
                             SpanAssertion::build(
                                 'slim.route.controller',
@@ -123,6 +128,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                             'http.status_code' => '200',
+                            'component' => 'slim',
                         ])->withChildren([
                             SpanAssertion::build(
                                 'slim.route.controller',
@@ -137,6 +143,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                                     'simple_view.phtml'
                                 )->withExactTags([
                                     'slim.view' => 'simple_view.phtml',
+                                    'component' => 'slim',
                                 ])
                             ])
                         ]),
@@ -152,6 +159,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                             'http.status_code' => '500',
+                            'component' => 'slim',
                         ])->setError(null, null)
                             ->withChildren([
                                 SpanAssertion::build(

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -101,6 +101,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'slim',
                     ])->withChildren([
                         $this->wrapMiddleware([
                             SpanAssertion::build(
@@ -110,6 +111,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                                 'Closure::__invoke'
                             )->withExactTags([
                                 'slim.route.name' => 'simple-route',
+                                'component' => 'slim',
                             ])
                         ]),
                     ]),
@@ -125,6 +127,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'slim',
                     ])->withChildren([
                         $this->wrapMiddleware([
                             SpanAssertion::build(
@@ -140,6 +143,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                                     'simple_view.phtml'
                                 )->withExactTags([
                                     'slim.view' => 'simple_view.phtml',
+                                    'component' => 'slim',
                                 ]),
                             ]),
                         ]),
@@ -156,6 +160,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'slim',
                     ])
                     ->setError(null, null)
                     ->withChildren([

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -38,6 +38,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
+                'component' => 'symfony',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -38,7 +38,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
-                'component' => 'symfony',
+                'component' => 'web.request',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V2_3/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_3/RouteNameTest.php
@@ -38,7 +38,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
-                'component' => 'web.request',
+                'component' => 'symfony',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -34,7 +34,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
-                'component' => 'symfony',
+                'component' => 'web.request',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -34,6 +34,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
+                'component' => 'symfony',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V2_8/RouteNameTest.php
+++ b/tests/Integrations/Symfony/V2_8/RouteNameTest.php
@@ -34,7 +34,7 @@ class RouteNameTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:' . self::PORT . '/' . ($isApache ? '' : 'app.php'),
                 'http.status_code' => '200',
-                'component' => 'web.request',
+                'component' => 'symfony',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_0/CommonScenariosTest.php
@@ -44,6 +44,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -76,6 +77,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -93,7 +95,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'symfony',
                                         'web',
                                         'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -114,6 +118,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -154,6 +159,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_0/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -44,6 +44,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -76,6 +77,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -94,7 +96,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'symfony',
                                         'web',
                                         'Symfony\Bundle\TwigBundle\TwigEngine twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -115,6 +119,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -156,6 +161,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -38,6 +38,7 @@ class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:9999/terminated_by_exit',
                 'http.status_code' => '200',
+                'component' => 'symfony',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -51,6 +51,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -85,6 +86,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -106,7 +108,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                             'test_symfony_34',
                                             'web',
                                             'Twig\Environment twig_template.html.twig'
-                                        )->withExactTags([]),
+                                        )->withExactTags([
+                                            'component' => 'symfony',
+                                        ]),
                                     ]),
                                     SpanAssertion::exists('symfony.kernel.response'),
                                     SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -128,6 +132,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                             'http.status_code' => '500',
+                            'component' => 'symfony',
                         ])
                         ->setError('Exception', 'An exception occurred')
                         ->withExistingTagsNames(['error.stack'])
@@ -179,6 +184,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                             'http.status_code' => '404',
+                            'component' => 'symfony',
                         ])
                         ->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
+++ b/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
@@ -31,6 +31,7 @@ class TemplateEnginesTest extends WebFrameworkTestCase
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost:9999/alternate_templating',
                 'http.status_code' => '200',
+                'component' => 'symfony',
             ])->withChildren([
                 SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                     SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -51,7 +52,9 @@ class TemplateEnginesTest extends WebFrameworkTestCase
                                 'symfony',
                                 'web',
                                 'Symfony\Component\Templating\PhpEngine php_template.template.php'
-                            )->withExactTags([]),
+                            )->withExactTags([
+                                'component' => 'symfony',
+                            ]),
                         ]),
                         SpanAssertion::exists('symfony.kernel.response'),
                         SpanAssertion::exists('symfony.kernel.finish_request'),

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -52,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -84,6 +85,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -103,7 +105,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'test_symfony_40',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -123,6 +127,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -164,6 +169,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -52,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -86,6 +87,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
                             SpanAssertion::exists('symfony.httpkernel.kernel.boot'),
@@ -103,7 +105,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'test_symfony_42',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.controller_arguments'),
                                 SpanAssertion::exists('symfony.kernel.response')->withChildren([
@@ -127,6 +131,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
                     ->withChildren([
@@ -166,6 +171,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V4_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_4/CommonScenariosTest.php
@@ -52,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -88,6 +89,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -107,7 +109,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'test_symfony_44',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.response')->withChildren([
                                     SpanAssertion::exists('symfony.security.authentication.success')
@@ -129,6 +133,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -181,6 +186,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_4/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V5_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V5_0/CommonScenariosTest.php
@@ -52,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -88,6 +89,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -107,7 +109,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'test_symfony_50',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.response')->withChildren([
                                     SpanAssertion::exists('symfony.security.authentication.success')
@@ -129,6 +133,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -181,6 +186,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_0/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V5_1/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V5_1/CommonScenariosTest.php
@@ -52,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -88,6 +89,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -107,7 +109,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'test_symfony_51',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.response')->withChildren([
                                     SpanAssertion::exists('symfony.security.authentication.success')
@@ -129,6 +133,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -181,6 +186,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_1/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_1/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Symfony/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V5_2/CommonScenariosTest.php
@@ -52,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')
                         ->withChildren([
@@ -86,6 +87,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([
@@ -105,7 +107,9 @@ class CommonScenariosTest extends WebFrameworkTestCase
                                         'test_symfony_52',
                                         'web',
                                         'Twig\Environment twig_template.html.twig'
-                                    )->withExactTags([]),
+                                    )->withExactTags([
+                                        'component' => 'symfony',
+                                    ]),
                                 ]),
                                 SpanAssertion::exists('symfony.kernel.response'),
                                 SpanAssertion::exists('symfony.kernel.finish_request'),
@@ -125,6 +129,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'symfony',
                     ])
                     ->setError('Exception', 'An exception occurred')
                     ->withExistingTagsNames(['error.stack'])
@@ -173,6 +178,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                         'http.status_code' => '404',
+                        'component' => 'symfony',
                     ])->withChildren([
                         SpanAssertion::exists('symfony.kernel.terminate'),
                         SpanAssertion::exists('symfony.httpkernel.kernel.handle')->withChildren([

--- a/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V5_2/TraceSearchConfigTest.php
@@ -44,6 +44,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost:9999/simple',
                     'http.status_code' => '200',
+                    'component' => 'symfony',
                 ])->withExactMetrics([
                     '_dd1.sr.eausr' => 0.3,
                     '_sampling_priority_v1' => 1,

--- a/tests/Integrations/Yii/V2_0/CommonScenariosTest.php
+++ b/tests/Integrations/Yii/V2_0/CommonScenariosTest.php
@@ -53,6 +53,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_STATUS_CODE => '200',
                         'app.endpoint' => 'app\controllers\SimpleController::actionIndex',
                         'app.route.path' => '/simple',
+                        'component' => 'yii',
                     ])->withChildren([
                         SpanAssertion::build(
                             'yii\web\Application.run',
@@ -88,6 +89,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_STATUS_CODE => '200',
                         'app.endpoint' => 'app\controllers\SimpleController::actionView',
                         'app.route.path' => '/simple_view',
+                        'component' => 'yii',
                     ])->withChildren([
                         SpanAssertion::build(
                             'yii\web\Application.run',
@@ -126,6 +128,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::HTTP_STATUS_CODE => '500',
                         'app.endpoint' => 'app\controllers\SimpleController::actionError',
                         'app.route.path' => '/error',
+                        'component' => 'yii',
                     ])
                         ->setError(
                             'Exception',

--- a/tests/Integrations/Yii/V2_0/ParameterizedRouteTest.php
+++ b/tests/Integrations/Yii/V2_0/ParameterizedRouteTest.php
@@ -43,6 +43,7 @@ class ParameterizedRouteTest extends WebFrameworkTestCase
                     Tag::HTTP_STATUS_CODE => '200',
                     'app.route.path' => '/homes/:state/:city/:neighborhood',
                     'app.endpoint' => 'app\controllers\HomesController::actionView',
+                    'component' => 'yii',
                 ])->withChildren([
                     SpanAssertion::build(
                         'yii\web\Application.run',

--- a/tests/Integrations/Yii/V2_0/YiiDetailsTest.php
+++ b/tests/Integrations/Yii/V2_0/YiiDetailsTest.php
@@ -44,6 +44,7 @@ class LazyLoadingIntegrationsFromYiiTest extends WebFrameworkTestCase
                     Tag::HTTP_STATUS_CODE => '200',
                     'app.route.path' => '/site/index',
                     'app.endpoint' => 'app\controllers\SiteController::actionIndex',
+                    'component' => 'yii',
                 ])->withChildren([
                     SpanAssertion::build(
                         'yii\web\Application.run',

--- a/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
+++ b/tests/Integrations/ZendFramework/V1/CommonScenariosTest.php
@@ -40,6 +40,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'zendframework',
                     ]),
             ],
             'A simple GET request with a view' => [
@@ -51,6 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
+                        'component' => 'zendframework',
                     ]),
             ],
             'A GET request with an exception' => [
@@ -62,6 +64,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/error?key=value&<redacted>',
                         'http.status_code' => '500',
+                        'component' => 'zendframework',
                     ]),
             ],
         ];

--- a/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
+++ b/tests/Integrations/ZendFramework/V1/TraceSearchConfigTest.php
@@ -41,6 +41,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost:9999/simple',
                         'http.status_code' => '200',
+                        'component' => 'zendframework',
                     ])
                     ->withExactMetrics([
                         '_dd1.sr.eausr' => 0.3,

--- a/tests/api/Unit/UserAvailableConstantsTest.php
+++ b/tests/api/Unit/UserAvailableConstantsTest.php
@@ -95,6 +95,7 @@ class UserAvailableConstantsTest extends BaseTestCase
             [Tag::MANUAL_DROP, 'manual.drop'],
             [Tag::PID, 'system.pid'],
             [Tag::RESOURCE_NAME, 'resource.name'],
+            [Tag::COMPONENT, 'component'],
             [Tag::DB_STATEMENT, 'sql.query'],
             [Tag::ERROR, 'error'],
             [Tag::ERROR_MSG, 'error.msg'],

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -34,9 +34,11 @@ object(DDTrace\SpanData)#%d (6) {
   ["type"]=>
   string(3) "cli"
   ["meta"]=>
-  array(1) {
+  array(2) {
     ["system.pid"]=>
     int(%d)
+    ["component"]=>
+    string(11) "web.request"
   }
   ["metrics"]=>
   array(0) {


### PR DESCRIPTION
Adds the `component` tag that was added in our integrations on original fork.