### PR TITLE
Refork - add SignalFX wrapper classes

### DIFF
--- a/bridge/_files_tracer.php
+++ b/bridge/_files_tracer.php
@@ -18,4 +18,6 @@ return [
     __DIR__ . '/../src/DDTrace/Http/Request.php',
     __DIR__ . '/../src/DDTrace/ScopeManager.php',
     __DIR__ . '/../src/DDTrace/Tracer.php',
+    __DIR__ . '/../src/SignalFx/GlobalTracer.php',
+    __DIR__ . '/../src/SignalFx/Tracing.php',
 ];

--- a/bridge/autoload.php
+++ b/bridge/autoload.php
@@ -94,7 +94,9 @@ spl_autoload_register(function ($class) use ($tracerFiles, $tracerFilesWithCompo
     // If $class is not a DDTrace class, move quickly to the next autoloader
     $prefix = 'DDTrace\\';
     $len = strlen($prefix);
-    if (strncmp($prefix, $class, $len) !== 0) {
+    // SIGNALFX: add SignalFx as a valid prefix for loading tracer files
+    $signalFxPrefix = 'SignalFx\\';
+    if (strncmp($prefix, $class, $len) !== 0 && strncmp($signalFxPrefix, $class, strlen($signalFxPrefix)) !== 0) {
         // move to the next registered autoloader
         return;
     }

--- a/src/SignalFx/GlobalTracer.php
+++ b/src/SignalFx/GlobalTracer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SignalFx;
+
+use DDTrace\GlobalTracer as DDGlobalTracer;
+
+/**
+ * GlobalTracer proxy
+ */
+final class GlobalTracer
+{
+    public static function get()
+    {
+        return DDGlobalTracer::get();
+    }
+}

--- a/src/SignalFx/Tracing.php
+++ b/src/SignalFx/Tracing.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SignalFx;
+
+use DDTrace\Integrations\IntegrationsLoader;
+use SignalFx\GlobalTracer;
+/**
+ * Tracing helpers
+ */
+final class Tracing
+{
+    /**
+     * Bootstrap the tracer and load all the integrations.
+     */
+    public static function autoInstrument()
+    {
+        IntegrationsLoader::load();
+    }
+
+    /**
+     * Call idempotent tracer creator and return registered global tracer.
+     */
+    public static function createTracer()
+    {
+        return GlobalTracer::get();
+    }
+}

--- a/src/SignalFx/Tracing.php
+++ b/src/SignalFx/Tracing.php
@@ -4,6 +4,7 @@ namespace SignalFx;
 
 use DDTrace\Integrations\IntegrationsLoader;
 use SignalFx\GlobalTracer;
+
 /**
  * Tracing helpers
  */

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -105,6 +105,8 @@ static void signalfx_memoize_alternates_names(zai_config_memoized_entry *memoize
     if (is_main) {
         signalfx_memoize_alternate_name(memoized, name, ZAI_STRL_VIEW("DD_TRACE_ENABLED"),
                                         ZAI_STRL_VIEW("SIGNALFX_TRACING_ENABLED"));
+        signalfx_memoize_alternate_name(memoized, name, ZAI_STRL_VIEW("DD_TRACE_CLI_ENABLED"),
+                                        ZAI_STRL_VIEW("SIGNALFX_TRACING_CLI_ENABLED"));
     }
 
     signalfx_memoize_alternate_prefix(memoized, name, ZAI_STRL_VIEW("DD_"), ZAI_STRL_VIEW("SIGNALFX_"));

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -105,8 +105,6 @@ static void signalfx_memoize_alternates_names(zai_config_memoized_entry *memoize
     if (is_main) {
         signalfx_memoize_alternate_name(memoized, name, ZAI_STRL_VIEW("DD_TRACE_ENABLED"),
                                         ZAI_STRL_VIEW("SIGNALFX_TRACING_ENABLED"));
-        signalfx_memoize_alternate_name(memoized, name, ZAI_STRL_VIEW("DD_TRACE_CLI_ENABLED"),
-                                        ZAI_STRL_VIEW("SIGNALFX_TRACING_CLI_ENABLED"));
     }
 
     signalfx_memoize_alternate_prefix(memoized, name, ZAI_STRL_VIEW("DD_"), ZAI_STRL_VIEW("SIGNALFX_"));


### PR DESCRIPTION
Adds the SignalFx wrapper classes back.

Additionally add `SIGNALFX_TRACING_CLI_ENABLED` as a valid alias for `DD_TRACE_CLI_ENABLED`, as that was used in original fork and may have been used by someone in their config.