### PR TITLE
Refork - minor changes to make output match original fork

### DIFF
--- a/ext/php7/configuration.h
+++ b/ext/php7/configuration.h
@@ -69,7 +69,7 @@ extern bool runtime_config_first_init;
     CONFIG(STRING, SIGNALFX_ACCESS_TOKEN, "")                                                                  \
     CONFIG(SET, SIGNALFX_CAPTURE_ENV_VARS, "")                                                                 \
     CONFIG(SET_LOWERCASE, SIGNALFX_CAPTURE_REQUEST_HEADERS, "")                                                \
-    CONFIG(INT, SIGNALFX_RECORDED_VALUE_MAX_LENGTH, "1024")                                                    \
+    CONFIG(INT, SIGNALFX_RECORDED_VALUE_MAX_LENGTH, "1200")                                                    \
     CONFIG(INT, SIGNALFX_ERROR_STACK_MAX_LENGTH, "8192")                                                       \
     CONFIG(BOOL, SIGNALFX_TRACE_JSON, "false")                                                                 \
     CONFIG(BOOL, SIGNALFX_TRACE_FILE_GET_CONTENTS, "false")                                                    \

--- a/ext/php7/serializer.c
+++ b/ext/php7/serializer.c
@@ -153,11 +153,11 @@ int ddtrace_serialize_simple_array_into_c_string(zval *trace, char **data_p, siz
     }
 }
 
-static int json_write_zval(json_writer_s *writer, zval *trace);
+static int json_write_zval(json_writer_s *writer, zval *trace, bool force_associative);
 
 // SIGNALFX: JSON equivalent for msgpack write_hash_table, additionally it does
 // not change trace/span IDs to number types as is done for msgpack
-static int json_write_hash_table(json_writer_s *writer, HashTable *ht) {
+static int json_write_hash_table(json_writer_s *writer, HashTable *ht, bool force_associative) {
     zval *tmp;
     zend_string *string_key;
     zend_long num_key;
@@ -170,6 +170,10 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht) {
     ZEND_HASH_FOREACH_BUCKET(ht, bucket) { is_assoc = is_assoc || bucket->key != NULL; }
     ZEND_HASH_FOREACH_END();
 #endif
+
+    if (force_associative) {
+        is_assoc = true;
+    }
 
     if (is_assoc) {
         json_writer_object_begin(writer);
@@ -186,11 +190,17 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht) {
             json_writer_element_separator(writer);
         }
 
+        bool known_associative_value = false;
+
         // Writing the key, if associative
         if (is_assoc == 1) {
             char num_str_buf[MAX_ID_BUFSIZ], *key;
             if (string_key) {
                 key = ZSTR_VAL(string_key);
+
+                if (strcmp(key, "tags") == 0) {
+                    known_associative_value = true;
+                }
             } else {
                 key = num_str_buf;
                 sprintf(num_str_buf, ZEND_LONG_FMT, num_key);
@@ -200,7 +210,7 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht) {
         }
 
         // Writing the value
-        if (json_write_zval(writer, tmp) != 1) {
+        if (json_write_zval(writer, tmp, known_associative_value) != 1) {
             return 0;
         }
     }
@@ -215,14 +225,14 @@ static int json_write_hash_table(json_writer_s *writer, HashTable *ht) {
 }
 
 // SIGNALFX: JSON equivalent for msgpack msgpack_write_zval
-static int json_write_zval(json_writer_s *writer, zval *trace) {
+static int json_write_zval(json_writer_s *writer, zval *trace, bool force_associative) {
     if (Z_TYPE_P(trace) == IS_REFERENCE) {
         trace = Z_REFVAL_P(trace);
     }
 
     switch (Z_TYPE_P(trace)) {
         case IS_ARRAY:
-            if (json_write_hash_table(writer, Z_ARRVAL_P(trace)) != 1) {
+            if (json_write_hash_table(writer, Z_ARRVAL_P(trace), force_associative) != 1) {
                 return 0;
             }
             break;
@@ -257,7 +267,7 @@ int ddtrace_serialize_simple_array_into_c_string_json(zval *trace, char **data_p
     size_t size;
     json_writer_s writer;
     json_writer_initialize(&writer);
-    if (json_write_zval(&writer, trace) != 1) {
+    if (json_write_zval(&writer, trace, false) != 1) {
         json_writer_destroy(&writer);
         return 0;
     }
@@ -1131,7 +1141,13 @@ void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span_t *spa
         zval *dd_service = zend_hash_str_find(Z_ARR_P(dd_span), ZEND_STRL("service"));
 
         if (dd_service != NULL && Z_TYPE_P(dd_service) == IS_STRING) {
-            _add_assoc_zval_copy(tags, SFX_TAG_COMPONENT, dd_service);
+            zend_string *default_service = get_DD_SERVICE();
+
+            // This is only a valid fallback value if it is custom from the integration and
+            // not the default service, which is already sent as localEndpoint['serviceName']
+            if (strcmp(ZSTR_VAL(default_service), Z_STRVAL_P(dd_service)) != 0) {
+                _add_assoc_zval_copy(tags, SFX_TAG_COMPONENT, dd_service);
+            }
         }
     }
 

--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -293,6 +293,9 @@ void ddtrace_startup_diagnostics(HashTable *ht, bool quick) {
             // SIGNALFX: Do not give the warning for the primary DD_ prefixed name
             if (strncmp(old_name->ptr, "DD_", 3) == 0 && strncmp(cfg->names[cfg->name_index - 1].ptr, "SIGNALFX_", 9) == 0) {
                 continue;
+            } else if (strcmp(old_name->ptr, "SIGNALFX_SERVICE_NAME") == 0) {
+                // This variation is preferred for SFX, do not warn
+                continue;
             }
             zend_string *message = zend_strpprintf(0, "'%s=%s' is deprecated, use %s instead.", old_name->ptr,
                                                    ZSTR_VAL(cfg->ini_entries[0]->value), cfg->names[0].ptr);

--- a/ext/php8/configuration.h
+++ b/ext/php8/configuration.h
@@ -69,7 +69,7 @@ extern bool runtime_config_first_init;
     CONFIG(STRING, SIGNALFX_ACCESS_TOKEN, "")                                                                  \
     CONFIG(SET, SIGNALFX_CAPTURE_ENV_VARS, "")                                                                 \
     CONFIG(SET_LOWERCASE, SIGNALFX_CAPTURE_REQUEST_HEADERS, "")                                                \
-    CONFIG(INT, SIGNALFX_RECORDED_VALUE_MAX_LENGTH, "1024")                                                    \
+    CONFIG(INT, SIGNALFX_RECORDED_VALUE_MAX_LENGTH, "1200")                                                    \
     CONFIG(INT, SIGNALFX_ERROR_STACK_MAX_LENGTH, "8192")                                                       \
     CONFIG(BOOL, SIGNALFX_TRACE_JSON, "false")                                                                 \
     CONFIG(BOOL, SIGNALFX_TRACE_FILE_GET_CONTENTS, "false")                                                    \

--- a/ext/php8/startup_logging.c
+++ b/ext/php8/startup_logging.c
@@ -293,6 +293,9 @@ void ddtrace_startup_diagnostics(HashTable *ht, bool quick) {
             // SIGNALFX: Do not give the warning for the primary DD_ prefixed name
             if (strncmp(old_name->ptr, "DD_", 3) == 0 && strncmp(cfg->names[cfg->name_index - 1].ptr, "SIGNALFX_", 9) == 0) {
                 continue;
+            } else if (strcmp(old_name->ptr, "SIGNALFX_SERVICE_NAME") == 0) {
+                // This variation is preferred for SFX, do not warn
+                continue;
             }
             zend_string *message = zend_strpprintf(0, "'%s=%s' is deprecated, use %s instead.", old_name->ptr,
                                                    ZSTR_VAL(cfg->ini_entries[0]->value), cfg->names[0].ptr);

--- a/signalfx-setup.php
+++ b/signalfx-setup.php
@@ -1201,7 +1201,7 @@ function get_ini_settings($requestInitHookPath)
         ],
         [
             'name' => 'signalfx.recorded_value_max_length',
-            'default' => '1024',
+            'default' => '1200',
             'commented' => true,
             'description' => 'Sets the maximum length of tag values in serialized format',
         ],

--- a/src/Integrations/Integrations/Builtins/BuiltinsIntegration.php
+++ b/src/Integrations/Integrations/Builtins/BuiltinsIntegration.php
@@ -27,6 +27,7 @@ class BuiltinsIntegration extends Integration
             \DDTrace\trace_function('file_get_contents', function (SpanData $span, $args, $result) {
                 $span->name = 'file_get_contents';
                 $span->meta['file.name'] = $args[0];
+                $span->type = 'custom';
                 if ($result === false) {
                     $span->meta[Tag::ERROR] = 'true';
                     $err = \error_get_last();
@@ -40,10 +41,12 @@ class BuiltinsIntegration extends Integration
         if (\sfx_trace_config_trace_json()) {
             \DDTrace\trace_function('json_encode', function (SpanData $span) {
                 $span->name = 'json_encode';
+                $span->type = 'custom';
             });
 
             \DDTrace\trace_function('json_decode', function (SpanData $span) {
                 $span->name = 'json_decode';
+                $span->type = 'custom';
             });
         }
 

--- a/tests/Integrations/Custom/NotAutoloaded/BuiltinsIntegrationsTest.php
+++ b/tests/Integrations/Custom/NotAutoloaded/BuiltinsIntegrationsTest.php
@@ -53,7 +53,7 @@ final class BuiltinsIntegrationsTest extends WebFrameworkTestCase
                     SpanAssertion::build(
                         'file_get_contents',
                         'my-service',
-                        'web',
+                        'custom',
                         'file_get_contents'
                     )->withExactTags([
                         'file.name' => '/proc/self/exe'
@@ -84,13 +84,13 @@ final class BuiltinsIntegrationsTest extends WebFrameworkTestCase
                     SpanAssertion::build(
                         'json_encode',
                         'my-service',
-                        'web',
+                        'custom',
                         'json_encode'
                     ),
                     SpanAssertion::build(
                         'json_decode',
                         'my-service',
-                        'web',
+                        'custom',
                         'json_decode'
                     )
                 ])


### PR DESCRIPTION
There were a few differences when comparing what was exported by the original fork and this one. This PR fixes those:

* `SIGNALFX_RECORDED_VALUE_MAX_LENGTH` default set to `1200` now
* `tags` exported as an object instead of array if empty now (otherwise caused collector to drop data)
* `component` only copied from `service` if it is not the default service from `SIGNALFX_SERVICE_NAME`
* Removed deprecated config name warning from `SIGNALFX_SERVICE_NAME`
* Made `json_encode`/`json_decode`/`file_get_contents` spans not get marked as `kind=server`