### PR TITLE
Refork - fix request_init_hook ini name in setup script

### DIFF
--- a/ext/php7/startup_logging.c
+++ b/ext/php7/startup_logging.c
@@ -296,6 +296,9 @@ void ddtrace_startup_diagnostics(HashTable *ht, bool quick) {
             } else if (strcmp(old_name->ptr, "SIGNALFX_SERVICE_NAME") == 0) {
                 // This variation is preferred for SFX, do not warn
                 continue;
+            } else if (strcmp(old_name->ptr, "DDTRACE_REQUEST_INIT_HOOK") == 0) {
+                // This variation is still necessary, do not warn
+                continue;
             }
             zend_string *message = zend_strpprintf(0, "'%s=%s' is deprecated, use %s instead.", old_name->ptr,
                                                    ZSTR_VAL(cfg->ini_entries[0]->value), cfg->names[0].ptr);

--- a/ext/php8/startup_logging.c
+++ b/ext/php8/startup_logging.c
@@ -296,6 +296,9 @@ void ddtrace_startup_diagnostics(HashTable *ht, bool quick) {
             } else if (strcmp(old_name->ptr, "SIGNALFX_SERVICE_NAME") == 0) {
                 // This variation is preferred for SFX, do not warn
                 continue;
+            } else if (strcmp(old_name->ptr, "DDTRACE_REQUEST_INIT_HOOK") == 0) {
+                // This variation is still necessary, do not warn
+                continue;
             }
             zend_string *message = zend_strpprintf(0, "'%s=%s' is deprecated, use %s instead.", old_name->ptr,
                                                    ZSTR_VAL(cfg->ini_entries[0]->value), cfg->names[0].ptr);

--- a/signalfx-setup.php
+++ b/signalfx-setup.php
@@ -1163,7 +1163,7 @@ function get_ini_settings($requestInitHookPath)
             'description' => 'Enables or disables tracing (set by the installer, do not change it)',
         ],
         [
-            'name' => 'signalfx.trace.request_init_hook',
+            'name' => 'ddtrace.request_init_hook',
             'default' => $requestInitHookPath,
             'commented' => false,
             'description' => 'Path to the request init hook (set by the installer, do not change it)',


### PR DESCRIPTION
The `ddtrace.request_init_hook` INI setting is hardcoded in the extension in a way that made the `signalfx.trace` prefix not work for that setting.