### PR TITLE
Error for first BGS failure, phpinfo text changes

### DIFF
--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -848,7 +848,7 @@ static PHP_MINFO_FUNCTION(ddtrace) {
             "https://docs.splunk.com/Observability/gdi/get-data-in/application/php/get-started.html");
     }
     datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
-    datadog_info_print("(c) Datadog 2020\n");
+    datadog_info_print("(c) Splunk 2022, Datadog 2020\n");
     php_info_print_box_end();
 
     php_info_print_table_start();

--- a/ext/php7/ddtrace.c
+++ b/ext/php7/ddtrace.c
@@ -836,23 +836,23 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
 
     php_info_print_box_start(0);
-    datadog_info_print("Datadog PHP tracer extension");
+    datadog_info_print("SignalFX PHP tracing extension");
     if (!sapi_module.phpinfo_as_text) {
         datadog_info_print("<br><strong>For help, check out ");
         datadog_info_print(
-            "<a href=\"https://docs.datadoghq.com/tracing/languages/php/\" "
+            "<a href=\"https://docs.splunk.com/Observability/gdi/get-data-in/application/php/get-started.html\" "
             "style=\"background:transparent;\">the documentation</a>.</strong>");
     } else {
         datadog_info_print(
             "\nFor help, check out the documentation at "
-            "https://docs.datadoghq.com/tracing/languages/php/");
+            "https://docs.splunk.com/Observability/gdi/get-data-in/application/php/get-started.html");
     }
     datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
     datadog_info_print("(c) Datadog 2020\n");
     php_info_print_box_end();
 
     php_info_print_table_start();
-    php_info_print_table_row(2, "Datadog tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
+    php_info_print_table_row(2, "SignalFX tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
     php_info_print_table_row(2, "Version", PHP_DDTRACE_VERSION);
     _dd_info_tracer_config();
     php_info_print_table_end();

--- a/ext/php7/logging.c
+++ b/ext/php7/logging.c
@@ -32,8 +32,7 @@ void ddtrace_bgs_log_mshutdown(void) {
     free(error_log);
 }
 
-#undef ddtrace_bgs_logf
-int ddtrace_bgs_logf(const char *fmt, ...) {
+int ddtrace_bgs_logf_always(const char *fmt, ...) {
     int ret = 0;
     char *error_log = (char *)atomic_load(&php_ini_error_log);
     if (error_log) {

--- a/ext/php7/logging.h
+++ b/ext/php7/logging.h
@@ -35,10 +35,10 @@ void ddtrace_bgs_log_minit(void);
 void ddtrace_bgs_log_rinit(char *error_log);
 void ddtrace_bgs_log_mshutdown(void);
 
-int ddtrace_bgs_logf(const char *fmt, ...);
+int ddtrace_bgs_logf_always(const char *fmt, ...);
 /* variadic functions cannot be inlined; we use a macro to essentially inline
  * the part we care about: the early return */
-#define ddtrace_bgs_logf(fmt, ...) (get_global_DD_TRACE_DEBUG_CURL_OUTPUT() ? ddtrace_bgs_logf(fmt, __VA_ARGS__) : 0)
+#define ddtrace_bgs_logf(fmt, ...) (get_global_DD_TRACE_DEBUG_CURL_OUTPUT() ? ddtrace_bgs_logf_always(fmt, __VA_ARGS__) : 0)
 /* }}} */
 
 #endif  // DD_LOGGING_H

--- a/ext/php8/coms.c
+++ b/ext/php8/coms.c
@@ -314,6 +314,7 @@ struct _writer_loop_data_t {
     struct _writer_thread_variables_t *thread;
 
     bool set_secbit;
+    bool first_send_attempted;
 
     _Atomic(bool) running, starting_up;
     _Atomic(pid_t) current_pid;
@@ -879,6 +880,33 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
     writer->headers = headers;
 }
 
+// SIGNALFX: always log the failure of first send failure regardless of curl logging setting
+static void signalfx_log_curl_errors(struct _writer_loop_data_t *writer, CURLcode res) {
+    long response_code = 0;
+
+    if (writer->first_send_attempted) {
+        return;
+    }
+
+    writer->first_send_attempted = true;
+
+    if (res == CURLE_OK) {
+        curl_easy_getinfo(writer->curl, CURLINFO_RESPONSE_CODE, &response_code);
+    }
+
+    if (res != CURLE_OK || response_code < 200 || response_code >= 300) {
+        char* url = signalfx_agent_url();
+
+        if (res != CURLE_OK) {
+            ddtrace_bgs_logf_always("[bgs] ERROR - First attempt to send traces to %s failed with error: %s\n", url, curl_easy_strerror(res));
+        } else {
+            ddtrace_bgs_logf_always("[bgs] ERROR - First attempt to send traces to %s failed with unexpected response code: %ld\n", url, response_code);
+        }
+
+        free(url);
+    }
+}
+
 static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms_stack_t *stack) {
     if (!writer->curl) {
         ddtrace_bgs_logf("[bgs] no curl session - dropping the current stack.\n", NULL);
@@ -911,6 +939,11 @@ static void _dd_curl_send_stack(struct _writer_loop_data_t *writer, ddtrace_coms
             double uploaded;
             curl_easy_getinfo(writer->curl, CURLINFO_SIZE_UPLOAD, &uploaded);
             ddtrace_bgs_logf("[bgs] uploaded %.0f bytes\n", uploaded);
+        }
+
+        // SIGNALFX: additional logging for SFX endpoints
+        if (get_global_SIGNALFX_MODE()) {
+            signalfx_log_curl_errors(writer, res);
         }
 
         _dd_deinit_read_userdata(read_data);

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -837,7 +837,7 @@ static PHP_MINFO_FUNCTION(ddtrace) {
             "https://docs.splunk.com/Observability/gdi/get-data-in/application/php/get-started.html");
     }
     datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
-    datadog_info_print("(c) Datadog 2020\n");
+    datadog_info_print("(c) Splunk 2022, Datadog 2020\n");
     php_info_print_box_end();
 
     php_info_print_table_start();

--- a/ext/php8/ddtrace.c
+++ b/ext/php8/ddtrace.c
@@ -825,23 +825,23 @@ static PHP_MINFO_FUNCTION(ddtrace) {
     UNUSED(zend_module);
 
     php_info_print_box_start(0);
-    datadog_info_print("Datadog PHP tracer extension");
+    datadog_info_print("SignalFX PHP tracing extension");
     if (!sapi_module.phpinfo_as_text) {
         datadog_info_print("<br><strong>For help, check out ");
         datadog_info_print(
-            "<a href=\"https://docs.datadoghq.com/tracing/languages/php/\" "
+            "<a href=\"https://docs.splunk.com/Observability/gdi/get-data-in/application/php/get-started.html\" "
             "style=\"background:transparent;\">the documentation</a>.</strong>");
     } else {
         datadog_info_print(
             "\nFor help, check out the documentation at "
-            "https://docs.datadoghq.com/tracing/languages/php/");
+            "https://docs.splunk.com/Observability/gdi/get-data-in/application/php/get-started.html");
     }
     datadog_info_print(!sapi_module.phpinfo_as_text ? "<br><br>" : "\n");
     datadog_info_print("(c) Datadog 2020\n");
     php_info_print_box_end();
 
     php_info_print_table_start();
-    php_info_print_table_row(2, "Datadog tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
+    php_info_print_table_row(2, "SignalFX tracing support", DDTRACE_G(disable) ? "disabled" : "enabled");
     php_info_print_table_row(2, "Version", PHP_DDTRACE_VERSION);
     _dd_info_tracer_config();
     php_info_print_table_end();

--- a/ext/php8/logging.c
+++ b/ext/php8/logging.c
@@ -32,8 +32,7 @@ void ddtrace_bgs_log_mshutdown(void) {
     free(error_log);
 }
 
-#undef ddtrace_bgs_logf
-int ddtrace_bgs_logf(const char *fmt, ...) {
+int ddtrace_bgs_logf_always(const char *fmt, ...) {
     int ret = 0;
     char *error_log = (char *)atomic_load(&php_ini_error_log);
     if (error_log) {

--- a/ext/php8/logging.h
+++ b/ext/php8/logging.h
@@ -35,10 +35,10 @@ void ddtrace_bgs_log_minit(void);
 void ddtrace_bgs_log_rinit(char *error_log);
 void ddtrace_bgs_log_mshutdown(void);
 
-int ddtrace_bgs_logf(const char *fmt, ...);
+int ddtrace_bgs_logf_always(const char *fmt, ...);
 /* variadic functions cannot be inlined; we use a macro to essentially inline
  * the part we care about: the early return */
-#define ddtrace_bgs_logf(fmt, ...) (get_global_DD_TRACE_DEBUG_CURL_OUTPUT() ? ddtrace_bgs_logf(fmt, __VA_ARGS__) : 0)
+#define ddtrace_bgs_logf(fmt, ...) (get_global_DD_TRACE_DEBUG_CURL_OUTPUT() ? ddtrace_bgs_logf_always(fmt, __VA_ARGS__) : 0)
 /* }}} */
 
 #endif  // DD_LOGGING_H


### PR DESCRIPTION
Since there is no probe during startup for SignalFX endpoints, the only way to see exporting fail in logs was to turn on `SIGNALFX_TRACE_DEBUG_CURL_OUTPUT`. In addition, response code was not checked. Made an error get logged always if first export fails, including when the response code is not in the 200 series.

Changed phpinfo output for the extension to report the extension as "SignalFX PHP tracing extension" with link to our documentation.