### PR TITLE
Implement Server-Timing header with trace+span ID

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -74,6 +74,7 @@ extern bool runtime_config_first_init;
     CONFIG(BOOL, SIGNALFX_TRACE_JSON, "false")                                                                 \
     CONFIG(BOOL, SIGNALFX_TRACE_FILE_GET_CONTENTS, "false")                                                    \
     CONFIG(BOOL, SIGNALFX_DRUPAL_RENAME_ROOT_SPAN, "true")                                                     \
+    CONFIG(BOOL, SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED, "false")                                              \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                         \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                              \
     CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -704,6 +704,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_PROPAGATION_STYLE_EXTRACT, ZAI_STRL_VIEW("B3,B3 single header"));
         zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_PROPAGATION_STYLE_INJECT, ZAI_STRL_VIEW("B3"));
         zai_config_use_signalfx_default(DDTRACE_CONFIG_DD_SERVICE, ZAI_STRL_VIEW("unnamed-php-service"));
+        zai_config_use_signalfx_default(DDTRACE_CONFIG_SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED, ZAI_STRL_VIEW("true"));
     }
 
     if (ZSTR_LEN(get_global_DD_SPAN_SAMPLING_RULES_FILE()) > 0) {

--- a/ext/span.c
+++ b/ext/span.c
@@ -123,7 +123,7 @@ static uint64_t _get_nanoseconds(bool monotonic_clock) {
     return 0;
 }
 
-// SIGNALFX: save 
+// SIGNALFX: send server timing header with trace/span ID if feature is enabled
 void signalfx_append_response_header(const char* full_header) {
     sapi_header_line header_line = {0};
     header_line.line = full_header;

--- a/ext/span.c
+++ b/ext/span.c
@@ -126,7 +126,7 @@ static uint64_t _get_nanoseconds(bool monotonic_clock) {
 // SIGNALFX: send server timing header with trace/span ID if feature is enabled
 void signalfx_append_response_header(const char* full_header) {
     sapi_header_line header_line = {0};
-    header_line.line = full_header;
+    header_line.line = (char*) full_header;
     header_line.line_len = strlen(full_header);
     header_line.response_code = 0;
     sapi_header_op(SAPI_HEADER_ADD, &header_line);

--- a/ext/startup_logging.c
+++ b/ext/startup_logging.c
@@ -354,19 +354,19 @@ static void _dd_print_values_to_log(HashTable *ht) {
     ZEND_HASH_FOREACH_STR_KEY_VAL_IND(ht, key, val) {
         switch (Z_TYPE_P(val)) {
             case IS_STRING:
-                ddtrace_log_errf("DATADOG TRACER DIAGNOSTICS - %s: %s", ZSTR_VAL(key), Z_STRVAL_P(val));
+                ddtrace_log_errf("SIGNALFX TRACER DIAGNOSTICS - %s: %s", ZSTR_VAL(key), Z_STRVAL_P(val));
                 break;
             case IS_NULL:
-                ddtrace_log_errf("DATADOG TRACER DIAGNOSTICS - %s: NULL", ZSTR_VAL(key));
+                ddtrace_log_errf("SIGNALFX TRACER DIAGNOSTICS - %s: NULL", ZSTR_VAL(key));
                 break;
             case IS_TRUE:
-                ddtrace_log_errf("DATADOG TRACER DIAGNOSTICS - %s: true", ZSTR_VAL(key));
+                ddtrace_log_errf("SIGNALFX TRACER DIAGNOSTICS - %s: true", ZSTR_VAL(key));
                 break;
             case IS_FALSE:
-                ddtrace_log_errf("DATADOG TRACER DIAGNOSTICS - %s: false", ZSTR_VAL(key));
+                ddtrace_log_errf("SIGNALFX TRACER DIAGNOSTICS - %s: false", ZSTR_VAL(key));
                 break;
             default:
-                ddtrace_log_errf("DATADOG TRACER DIAGNOSTICS - %s: {unknown type}", ZSTR_VAL(key));
+                ddtrace_log_errf("SIGNALFX TRACER DIAGNOSTICS - %s: {unknown type}", ZSTR_VAL(key));
                 break;
         }
     }
@@ -389,7 +389,7 @@ void ddtrace_startup_logging_first_rinit(void) {
 
     smart_str buf = {0};
     _dd_serialize_json(ht, &buf, 0);
-    ddtrace_log_errf("DATADOG TRACER CONFIGURATION - %s", ZSTR_VAL(buf.s));
+    ddtrace_log_errf("SIGNALFX TRACER CONFIGURATION - %s", ZSTR_VAL(buf.s));
     ddtrace_log_errf(
         "For additional diagnostic checks such as Agent connectivity, see the 'signalfx_tracing' section of a "
         "phpinfo() page. Alternatively set SIGNALFX_TRACE_DEBUG=1 to add diagnostic checks to the error logs on the "

--- a/signalfx-setup.php
+++ b/signalfx-setup.php
@@ -1268,6 +1268,12 @@ function get_ini_settings($requestInitHookPath)
             'description' => 'Ingest access token, which is required if sending directly to the ingest endpoint',
         ],
         [
+            'name' => 'signalfx.trace.response_header_enabled',
+            'default' => 'On',
+            'commented' => true,
+            'description' => 'Sets whether setting the response header that links with RUM traces is enabled',
+        ],
+        [
             'name' => 'signalfx.capture_env_vars',
             'default' => '',
             'commented' => true,

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -160,7 +160,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
     }
 
     /**
-     * Executed a call to the test web server.
+     * SIGNALFX: Executed a call to the test web server and returns response array(body, headers)
      *
      * @param RequestSpec $spec
      * @return mixed|null

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -189,13 +189,13 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             if ($headers) {
                 curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             }
-            curl_setopt($ch, CURLOPT_HEADERFUNCTION, function($curl, $header) use (&$responseHeaders) {
+            curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
                 $splitHeader = explode(':', $header, 2);
-    
+
                 if (count($splitHeader) == 2) {
                     $responseHeaders[strtolower(trim($splitHeader[0]))][] = trim($splitHeader[1]);
                 }
-    
+
                 return strlen($header);
             });
             $response = curl_exec($ch);

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -155,7 +155,33 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
      */
     protected function sendRequest($method, $url, $headers = [])
     {
+        list($responseBody, $responseHeaders) = $this->sendRequestWithResponseHeaders($method, $url, $headers);
+        return $responseBody;
+    }
+
+    /**
+     * Executed a call to the test web server.
+     *
+     * @param RequestSpec $spec
+     * @return mixed|null
+     */
+    protected function callWithResponseHeaders(RequestSpec $spec)
+    {
+        $response = $this->sendRequestWithResponseHeaders(
+            $spec->getMethod(),
+            self::HOST . ':' . self::PORT . $spec->getPath(),
+            $spec->getHeaders()
+        );
+        return $response;
+    }
+
+    protected function sendRequestWithResponseHeaders($method, $url, $headers = [])
+    {
+        // SIGNALFX: collect headers too
+        $responseHeaders = null;
+
         for ($i = 0; $i < 10; ++$i) {
+            $responseHeaders = array();
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
@@ -163,6 +189,15 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             if ($headers) {
                 curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             }
+            curl_setopt($ch, CURLOPT_HEADERFUNCTION, function($curl, $header) use (&$responseHeaders) {
+                $splitHeader = explode(':', $header, 2);
+    
+                if (count($splitHeader) == 2) {
+                    $responseHeaders[strtolower(trim($splitHeader[0]))][] = trim($splitHeader[1]);
+                }
+    
+                return strlen($header);
+            });
             $response = curl_exec($ch);
             if ($response === false && $i < 9) {
                 \curl_close($ch);
@@ -191,6 +226,7 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
 
         curl_close($ch);
 
-        return $response;
+        // SIGNALFX: collect headers too
+        return array($response, $responseHeaders);
     }
 }

--- a/tests/DistributedTracing/SignalFxResponseHeadersTest.php
+++ b/tests/DistributedTracing/SignalFxResponseHeadersTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace DDTrace\Tests\DistributedTracing;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+
+// SIGNALFX: Test that SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED sets Server-Timing header
+class SignalFxResponseHeadersTest extends WebFrameworkTestCase
+{
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        /* Here we are disabling ddtrace for the test harness so that it doesn't
+         * instrument the curl call and alter the x-datadog headers. */
+        \dd_trace_disable_in_request();
+    }
+
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../Frameworks/Custom/Version_Not_Autoloaded/index.php';
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            'DD_DISTRIBUTED_TRACING' => 'true',
+            'DD_TRACE_NO_AUTOLOADER' => 'true',
+            'SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED' => 'true'
+        ]);
+    }
+
+    public function testResponseHeader()
+    {
+        $responseHeaders = null;
+        $traces = $this->tracesFromWebRequest(function () use (&$responseHeaders) {
+            $spec = new RequestSpec(
+                __FUNCTION__,
+                'GET',
+                '/index.php',
+                [
+                    'X-B3-TraceId: 100a',
+                    'X-B3-SpanId: 100b',
+                ]
+            );
+            list($response, $headers) = $this->callWithResponseHeaders($spec);
+            $responseHeaders = $headers;
+        });
+
+        $this->assertSame('4106', $traces[0][0]['trace_id']);
+        $this->assertSame('4107', $traces[0][0]['parent_id']);
+
+        $serverTimingHeaders = $responseHeaders['server-timing'];
+        $this->assertNotNull($serverTimingHeaders);
+        $this->assertSame(1, count($serverTimingHeaders));
+
+        $matched = preg_match('/^traceparent;desc="00-([a-z0-9]{32,32})-([a-z0-9]{16,16})-01"$/', $serverTimingHeaders[0], $matches);
+        $this->assertSame(1, $matched);
+
+        $this->assertSame($matches[1], '0000000000000000000000000000100a');
+        $this->assertNotSame($matches[2], '0000000000000000000000000000100b');
+    }
+}

--- a/tests/DistributedTracing/SignalFxResponseHeadersTest.php
+++ b/tests/DistributedTracing/SignalFxResponseHeadersTest.php
@@ -54,8 +54,11 @@ class SignalFxResponseHeadersTest extends WebFrameworkTestCase
         $this->assertNotNull($serverTimingHeaders);
         $this->assertSame(1, count($serverTimingHeaders));
 
-        $matched = preg_match('/^traceparent;desc="00-([a-z0-9]{32,32})-([a-z0-9]{16,16})-01"$/',
-            $serverTimingHeaders[0], $matches);
+        $matched = preg_match(
+            '/^traceparent;desc="00-([a-z0-9]{32,32})-([a-z0-9]{16,16})-01"$/',
+            $serverTimingHeaders[0],
+            $matches
+        );
         $this->assertSame(1, $matched);
 
         $this->assertSame($matches[1], '0000000000000000000000000000100a');

--- a/tests/DistributedTracing/SignalFxResponseHeadersTest.php
+++ b/tests/DistributedTracing/SignalFxResponseHeadersTest.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\DistributedTracing;
 
 use DDTrace\Tests\Common\WebFrameworkTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;\
 
 // SIGNALFX: Test that SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED sets Server-Timing header
 class SignalFxResponseHeadersTest extends WebFrameworkTestCase
@@ -54,7 +54,8 @@ class SignalFxResponseHeadersTest extends WebFrameworkTestCase
         $this->assertNotNull($serverTimingHeaders);
         $this->assertSame(1, count($serverTimingHeaders));
 
-        $matched = preg_match('/^traceparent;desc="00-([a-z0-9]{32,32})-([a-z0-9]{16,16})-01"$/', $serverTimingHeaders[0], $matches);
+        $matched = preg_match('/^traceparent;desc="00-([a-z0-9]{32,32})-([a-z0-9]{16,16})-01"$/',
+            $serverTimingHeaders[0], $matches);
         $this->assertSame(1, $matched);
 
         $this->assertSame($matches[1], '0000000000000000000000000000100a');

--- a/tests/DistributedTracing/SignalFxResponseHeadersTest.php
+++ b/tests/DistributedTracing/SignalFxResponseHeadersTest.php
@@ -3,7 +3,7 @@
 namespace DDTrace\Tests\DistributedTracing;
 
 use DDTrace\Tests\Common\WebFrameworkTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;\
+use DDTrace\Tests\Frameworks\Util\Request\RequestSpec;
 
 // SIGNALFX: Test that SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED sets Server-Timing header
 class SignalFxResponseHeadersTest extends WebFrameworkTestCase

--- a/tests/Integrations/Custom/Autoloaded/StartupLoggingDiagnosticsTest.php
+++ b/tests/Integrations/Custom/Autoloaded/StartupLoggingDiagnosticsTest.php
@@ -52,7 +52,7 @@ final class StartupLoggingDiagnosticsTest extends WebFrameworkTestCase
 
         $contents = \file_get_contents(self::getAppErrorLog());
 
-        self::assertStringContains('DATADOG TRACER DIAGNOSTICS - agent_error:', $contents);
-        self::assertStringContains('DATADOG TRACER DIAGNOSTICS - datadog.trace.request_init_hook_reachable:', $contents);
+        self::assertStringContains('SIGNALFX TRACER DIAGNOSTICS - agent_error:', $contents);
+        self::assertStringContains('SIGNALFX TRACER DIAGNOSTICS - datadog.trace.request_init_hook_reachable:', $contents);
     }
 }

--- a/tests/Integrations/Custom/Autoloaded/StartupLoggingDisabledTest.php
+++ b/tests/Integrations/Custom/Autoloaded/StartupLoggingDisabledTest.php
@@ -51,6 +51,6 @@ final class StartupLoggingDisabledTest extends WebFrameworkTestCase
 
         $contents = \file_get_contents(self::getAppErrorLog());
 
-        self::assertStringNotContains('DATADOG TRACER CONFIGURATION', $contents);
+        self::assertStringNotContains('SIGNALFX TRACER CONFIGURATION', $contents);
     }
 }

--- a/tests/Integrations/Custom/Autoloaded/StartupLoggingTest.php
+++ b/tests/Integrations/Custom/Autoloaded/StartupLoggingTest.php
@@ -90,7 +90,7 @@ final class StartupLoggingTest extends WebFrameworkTestCase
         $contents = \file_get_contents(self::getAppErrorLog());
         $lines = explode(PHP_EOL, $contents);
 
-        $target = 'DATADOG TRACER CONFIGURATION - ';
+        $target = 'SIGNALFX TRACER CONFIGURATION - ';
         $json = '';
         foreach ($lines as $line) {
             $pos = strpos($line, $target);

--- a/tests/ext/startup_logging.inc
+++ b/tests/ext/startup_logging.inc
@@ -29,7 +29,7 @@ function dd_get_startup_logs(array $args = [], array $env = [])
     $cmd = $envVars . ' ' . $cgi . ' ' . getenv("TEST_PHP_EXTRA_ARGS") . ' ' . $argList . ' -v 2>&1';
     exec($cmd, $o);
 
-    $target = 'DATADOG TRACER CONFIGURATION - ';
+    $target = 'SIGNALFX TRACER CONFIGURATION - ';
     $json = '';
     foreach ($o as $line) {
         $pos = strpos($line, $target);


### PR DESCRIPTION
Adds `Server-Timing` (and `Access-Control-Expose-Headers` to expose it to browsers) header to response headers if `SIGNALFX_TRACE_RESPONSE_HEADER_ENABLED` is enabled (enabled by default for signalfx distribution) which contains `traceparent` as specified by W3C:

https://w3.org/TR/server-timing
https://w3.org/TR/trace-context

For example:
`Server-Timing: traceparent;desc="00-009e48a5d5e5101549a8415a9d5786e1-018596472ae51569-01"`
`Access-Control-Expose-Headers: Server-Timing`