### PR TITLE
Fix error set as boolean, release 0.83.1-beta-sfx10

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1129,7 +1129,7 @@ void signalfx_serialize_sfx_span_to_array(zval* spans_array, ddtrace_span_data *
     }
 
     if (error_kind_present) {
-        add_assoc_bool(tags, "error", true);
+        add_assoc_string(tags, "error", "true");
     }
 
     // Pseudo: sfx_span['tags']['component'] = dd_span['service'] (if tag not yet present)

--- a/ext/version.h
+++ b/ext/version.h
@@ -1,4 +1,4 @@
 #ifndef PHP_DDTRACE_VERSION
 // Must begin with a number for Debian packaging requirements
-#define PHP_DDTRACE_VERSION "0.83.1-beta-sfx9"
+#define PHP_DDTRACE_VERSION "0.83.1-beta-sfx10"
 #endif

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -24,7 +24,7 @@ final class Tracer implements TracerInterface
      * Must begin with a number for Debian packaging requirements
      * Must use single-quotes for packaging script to work
      */
-    const VERSION = '0.83.1-beta-sfx9';
+    const VERSION = '0.83.1-beta-sfx10';
 
     /**
      * @var Span[][]

--- a/tests/ext/signalfx/signalfx_test_span_conversion.phpt
+++ b/tests/ext/signalfx/signalfx_test_span_conversion.phpt
@@ -62,7 +62,7 @@ array(1) {
       ["random"]=>
       string(9) "dd_random"
       ["error"]=>
-      bool(true)
+      string(4) "true"
       ["resource.name"]=>
       string(11) "dd_resource"
     }

--- a/tests/ext/signalfx/signalfx_test_span_conversion_cases.phpt
+++ b/tests/ext/signalfx/signalfx_test_span_conversion_cases.phpt
@@ -82,7 +82,7 @@ missing
 present
 
 ERROR TAG
-1
+true
 missing
 
 COMPONENT TAG


### PR DESCRIPTION
The signalfx-forwarder in collector does not accept tags with non-string values, but the agent set "error" tag to boolean true, instead of string.